### PR TITLE
Add font padding setting

### DIFF
--- a/Core/CoreSettings.cs
+++ b/Core/CoreSettings.cs
@@ -98,6 +98,8 @@ namespace ExileCore
         public ListNode Font { get; set; } = new ListNode {Values = new List<string> {"Not found"}};
         [IgnoreMenu] // "Currently not works. Because this option broke calculate how much pixels needs for render."
         public RangeNode<int> FontSize { get; set; } = new RangeNode<int>(13, 7, 36);
+        [Menu("Font Spacing", 2, 5000)]
+        public RangeNode<float> FontSpacing { get; set; } = new RangeNode<float>(1, 0.5f, 2);
         [Menu("Volume", 3, 5000)]
         public RangeNode<int> Volume { get; set; } = new RangeNode<int>(100, 0, 100);
         #endregion

--- a/Core/Graphics.cs
+++ b/Core/Graphics.cs
@@ -92,12 +92,12 @@ namespace ExileCore
 
         public Vector2N MeasureText(string text)
         {
-            return ImGuiRender.MeasureText(text);
+            return ImGuiRender.MeasureText(text).Mult(_settings.FontSpacing, 1);
         }
 
         public Vector2N MeasureText(string text, int height)
         {
-            return ImGuiRender.MeasureText(text, height);
+            return ImGuiRender.MeasureText(text, height).Mult(_settings.FontSpacing, 1);
         }
 
         public void DrawLine(Vector2N p1, Vector2N p2, float borderWidth, Color color)


### PR DESCRIPTION
Better support for non-1080p resolutions, padding around text can be manually adjusted to avoid overlaps