### PR TITLE
Fix files table size again

### DIFF
--- a/Core/PoEMemory/FilesFromMemory.cs
+++ b/Core/PoEMemory/FilesFromMemory.cs
@@ -34,7 +34,7 @@ namespace ExileCore.PoEMemory
         {
             var files = new ConcurrentDictionary<string, FileInformation>();
             var fileRootAddress = _mem.AddressOfProcess + _mem.BaseOffsets[OffsetsName.FileRoot];
-            Parallel.For(0, 256, i => {
+            Parallel.For(0, 128, i => {
                 var fileAddress = fileRootAddress + i * 0x40;
                 var fileChunk = _mem.Read<FilesOffsets>(fileAddress);
                 ReadDictionary(fileChunk.ListPtr, files);
@@ -71,7 +71,7 @@ namespace ExileCore.PoEMemory
         {
             var files = new ConcurrentDictionary<string, FileInformation>();
             var fileRootAddress = _mem.AddressOfProcess + _mem.BaseOffsets[OffsetsName.FileRoot];
-            Parallel.For(0, 256, i => {
+            Parallel.For(0, 128, i => {
                 var fileAddress = fileRootAddress + i * 0x40;
                 var fileChunk = _mem.Read<FilesOffsets>(fileAddress);
                 ReadDictionary(fileChunk.ListPtr, files);


### PR DESCRIPTION
From where we get the FileRoot pattern, which is initialization of the files table, we get the size of the table in R8D (=0x80)

```
       140ff70a1 4c 8d 0d        LEA        R9,[FUN_140ff75b0]
                 08 05 00 00
       140ff70a8 ba 40 00        MOV        EDX,0x40
                 00 00
       140ff70ad 44 8d 42 40     LEA        R8D,[RDX + 0x40]
       140ff70b1 48 8b cd        MOV        RCX=>aa_FILE_ROOT,RBP                            = ??
                             LAB_140ff70b4                                   XREF[1]:     143120960(*)  
       140ff70b4 e8 23 30        CALL       aa_apply_foreach                                 undefined aa_apply_foreach(undef
                 82 00
```

Alternatively, try to fetch all files from [128, 256) and inspect the results.

cc @snowhawk04