### PR TITLE
update some nuget dependencies to latest stable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+end_of_line = lf

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\LibGit2Sharp.NativeBinaries.2.0.306\build\net46\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.2.0.306\build\net46\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="..\packages\InlineIL.Fody.1.3.2\build\InlineIL.Fody.props" Condition="Exists('..\packages\InlineIL.Fody.1.3.2\build\InlineIL.Fody.props')" />
@@ -89,17 +89,11 @@
       <HintPath>..\packages\ProcessMemoryUtilities.Net.1.2.0\lib\net48\ProcessMemoryUtilities.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
-      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Serilog.Sinks.File.4.1.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -82,8 +82,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PoeFilterParser, Version=1.0.44.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PoeFilterParser.1.0.44\lib\net471\PoeFilterParser.dll</HintPath>
+    <Reference Include="PoeFilterParser, Version=1.0.58.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PoeFilterParser.1.0.58\lib\net48\PoeFilterParser.dll</HintPath>
     </Reference>
     <Reference Include="ProcessMemoryUtilities, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\ProcessMemoryUtilities.Net.1.2.0\lib\net48\ProcessMemoryUtilities.dll</HintPath>

--- a/Core/Logger.cs
+++ b/Core/Logger.cs
@@ -12,15 +12,15 @@ namespace ExileCore
                 .ControlledBy(new LoggingLevelSwitch(LogEventLevel.Verbose)).WriteTo
                 .Logger(l => l.Filter.ByIncludingOnly(
                         e => e.Level == LogEventLevel.Information).WriteTo
-                    .RollingFile(@"Logs\Info-{Date}.log")).WriteTo
+                    .File(@"Logs\Info-.log", rollingInterval: RollingInterval.Day)).WriteTo
                 .Logger(l => l.Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Debug)
-                    .WriteTo.RollingFile(@"Logs\Debug-{Date}.log")).WriteTo
+                    .WriteTo.File(@"Logs\Debug-.log", rollingInterval: RollingInterval.Day)).WriteTo
                 .Logger(l => l.Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                    .WriteTo.RollingFile(@"Logs\Warning-{Date}.log")).WriteTo
+                    .WriteTo.File(@"Logs\Warning-.log", rollingInterval: RollingInterval.Day)).WriteTo
                 .Logger(l => l.Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Error)
-                    .WriteTo.RollingFile(@"Logs\Error-{Date}.log")).WriteTo
+                    .WriteTo.File(@"Logs\Error-.log", rollingInterval: RollingInterval.Day)).WriteTo
                 .Logger(l => l.Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Fatal)
-                    .WriteTo.RollingFile(@"Logs\Fatal-{Date}.log")).WriteTo
-                .RollingFile(@"Logs\Verbose-{Date}.log").CreateLogger());
+                    .WriteTo.File(@"Logs\Fatal-.log", rollingInterval: RollingInterval.Day)).WriteTo
+                .File(@"Logs\Verbose-.log", rollingInterval: RollingInterval.Day).CreateLogger());
     }
 }

--- a/Core/app.config
+++ b/Core/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -13,7 +13,7 @@
   <package id="morelinq" version="3.2.0" targetFramework="net48" />
   <package id="MouseKeyHook" version="5.6.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="PoeFilterParser" version="1.0.44" targetFramework="net48" />
+  <package id="PoeFilterParser" version="1.0.58" targetFramework="net48" />
   <package id="ProcessMemoryUtilities.Net" version="1.2.0" targetFramework="net48" />
   <package id="Serilog" version="2.10.0" targetFramework="net48" />
   <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net48" />

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net48" />
   <package id="Fody" version="6.0.0" targetFramework="net48" developmentDependency="true" />
@@ -15,9 +15,8 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="PoeFilterParser" version="1.0.44" targetFramework="net48" />
   <package id="ProcessMemoryUtilities.Net" version="1.2.0" targetFramework="net48" />
-  <package id="Serilog" version="2.8.0" targetFramework="net48" />
-  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net48" />
-  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net48" />
+  <package id="Serilog" version="2.10.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net472" />
   <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net472" />
   <package id="SharpDX.Desktop" version="4.2.0" targetFramework="net472" />

--- a/Loader/Loader.csproj
+++ b/Loader/Loader.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Net.Compilers.3.2.1\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.3.2.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
@@ -51,17 +51,11 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="mscorlib" />
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
-      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
-      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
-      <HintPath>..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.1.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>

--- a/Loader/packages.config
+++ b/Loader/packages.config
@@ -1,10 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="3.2.1" targetFramework="net48" developmentDependency="true" />
-  <package id="Serilog" version="2.8.0" targetFramework="net48" />
-  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net48" />
-  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net48" />
+  <package id="Serilog" version="2.10.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net472" />
   <package id="SharpDX.D3DCompiler" version="4.2.0" targetFramework="net472" />
   <package id="SharpDX.Desktop" version="4.2.0" targetFramework="net472" />


### PR DESCRIPTION
This updates several nuget dependencies to the latest stable version.

There are no significant functional changes, other than eliminating the use
of a deprecated logfile rotation module in favour of the upstream version
integrated into the base file log sink.

This does help me verify I can make more substantial changes and test
them correctly before doing anything bigger, though.