### PR TITLE
fix log spam when exileapi is launched before poe client

### DIFF
--- a/Core/Core.cs
+++ b/Core/Core.cs
@@ -350,7 +350,7 @@ namespace ExileCore
 
                     try
                     {
-                        _mainMenu.Render(GameController, pluginManager.Plugins);
+                        _mainMenu.Render(GameController, pluginManager?.Plugins);
                     }
                     catch (Exception e)
                     {
@@ -397,7 +397,7 @@ namespace ExileCore
 
                     if (_coreSettings.CollectDebugInformation)
                     {
-                        foreach (var plugin in pluginManager.Plugins)
+                        foreach (var plugin in pluginManager?.Plugins)
                         {
                             if (!plugin.IsEnable) continue;
                             if (!GameController.InGame && !plugin.Force) continue;
@@ -418,7 +418,7 @@ namespace ExileCore
                     }
                     else
                     {
-                        foreach (var plugin in pluginManager.Plugins)
+                        foreach (var plugin in pluginManager?.Plugins)
                         {
                             if (!plugin.IsEnable) continue;
                             if (!GameController.InGame && !plugin.Force) continue;
@@ -471,7 +471,7 @@ namespace ExileCore
 
                     if (_coreSettings.CollectDebugInformation)
                     {
-                        foreach (var plugin in pluginManager.Plugins)
+                        foreach (var plugin in pluginManager?.Plugins)
                         {
                             if (!plugin.IsEnable) continue;
                             if (!plugin.CanRender) continue;
@@ -481,7 +481,7 @@ namespace ExileCore
                     }
                     else
                     {
-                        foreach (var plugin in pluginManager.Plugins)
+                        foreach (var plugin in pluginManager?.Plugins)
                         {
                             if (!plugin.IsEnable) continue;
                             if (!GameController.InGame && !plugin.Force) continue;

--- a/Core/EntityListWrapper.cs
+++ b/Core/EntityListWrapper.cs
@@ -205,11 +205,9 @@ namespace ExileCore
 
         public void RefreshState()
         {
-            if (gameController.Area.CurrentArea == null 
-                /*|| !EntitiesStack.CanRead */ 
-                || entityCollectSettingsContainer.NeedUpdate 
-                || !Player.IsValid)
-                return;
+            if (gameController.Area.CurrentArea == null) return;
+            if (entityCollectSettingsContainer.NeedUpdate) return;
+            if (Player == null || !Player.IsValid) return;
 
             while (Simple.Count > 0)
             {

--- a/Core/MenuWindow.cs
+++ b/Core/MenuWindow.cs
@@ -197,9 +197,12 @@ namespace ExileCore
 
         public unsafe void Render(GameController _gameController, List<PluginWrapper> plugins)
         {
-            if (plugins != null) plugins = plugins.OrderBy(x => x.Name).ToList();
+            plugins = plugins?.OrderBy(x => x.Name).ToList();
 
-            if (CoreSettings.ShowDebugWindow) debugInformation.TickAction(DebugWindowRender);
+            if (CoreSettings.ShowDebugWindow)
+            {
+                debugInformation.TickAction(DebugWindowRender);
+            }
 
             if (CoreSettings.MainMenuKeyToggle.PressedOnce())
             {


### PR DESCRIPTION
This removes error log spam caused by a null dereference in the per-tick handler when ExileAPI is launched before the PoE client.  While the error is caught, it can generate an awful large log quickly, and makes finding other errors more difficult.

Bonus: generate full debug symbols even in release builds, to make debugging easier.