### PR TITLE
Item Base Component updates

### DIFF
--- a/Core/PoEMemory/Components/Base.cs
+++ b/Core/PoEMemory/Components/Base.cs
@@ -1,26 +1,39 @@
+using ExileCore.Shared.Enums;
 using ExileCore.Shared.Helpers;
 using GameOffsets.Native;
-using ExileCore.Shared.Enums;
+using GameOffsets;
+using ExileCore.Shared.Cache;
 
 namespace ExileCore.PoEMemory.Components
 {
     public class Base : Component
     {
+        private readonly CachedValue<BaseComponentOffsets> _cachedValue;
+
+        public Base()
+        {
+            _cachedValue = new FrameCache<BaseComponentOffsets>(() => M.Read<BaseComponentOffsets>(Address));
+        }
+
+        public BaseComponentOffsets BaseStruct => _cachedValue.Value;
+
         //x20 - some strings about item
         private string _name;
         public string Name => _name ?? (_name = M.Read<NativeStringU>(Address + 0x10, 0x18).ToString(M));
         public int ItemCellsSizeX => M.Read<int>(Address + 0x10, 0x10);
         public int ItemCellsSizeY => M.Read<int>(Address + 0x10, 0x14);
-		private Influence InfluenceFlag => (Influence)M.Read<byte>(Address + 0xD8);
-		public bool isShaper => (InfluenceFlag & Influence.Shaper) == Influence.Shaper;
-		public bool isElder => (InfluenceFlag & Influence.Elder) == Influence.Elder;
-		public bool isCrusader => (InfluenceFlag & Influence.Crusader) == Influence.Crusader;
-		public bool isHunter => (InfluenceFlag & Influence.Hunter) == Influence.Hunter;
-		public bool isRedeemer => (InfluenceFlag & Influence.Redeemer) == Influence.Redeemer;
-		public bool isWarlord => (InfluenceFlag & Influence.Warlord) == Influence.Warlord;
-		public bool isCorrupted => M.Read<byte>(Address + 0xDA) == 1;
-		public bool isSynthesized => M.Read<byte>(Address + 0xDE) == 1;
-        public string PublicPrice => M.Read<NativeStringU>(Address + 0x60).ToString(M); // TODO: 3.12.2
+        private Influence InfluenceFlag => (Influence)BaseStruct.InfluenceFlag;
+        public bool isShaper => (InfluenceFlag & Influence.Shaper) == Influence.Shaper;
+        public bool isElder => (InfluenceFlag & Influence.Elder) == Influence.Elder;
+        public bool isCrusader => (InfluenceFlag & Influence.Crusader) == Influence.Crusader;
+        public bool isHunter => (InfluenceFlag & Influence.Hunter) == Influence.Hunter;
+        public bool isRedeemer => (InfluenceFlag & Influence.Redeemer) == Influence.Redeemer;
+        public bool isWarlord => (InfluenceFlag & Influence.Warlord) == Influence.Warlord;
+        public bool isCorrupted => BaseStruct.isCorrupted;
+        public bool isSynthesized => BaseStruct.isSynthesized;
+        // REVISIT: not using Cache.StringCache here.  no profiles
+        // point to it being used often enough in a single frame.
+        public string PublicPrice => M.Read<NativeStringU>(BaseStruct.PublicPricePtr).ToString(M); // TODO: 3.12.2
 
         // public bool isFractured => M.Read<byte>(Address + 0x98) == 0; // TODO: 3.12.2
 

--- a/GameOffsets/BaseComponentOffsets.cs
+++ b/GameOffsets/BaseComponentOffsets.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+using GameOffsets.Native;
+
+namespace GameOffsets
+{
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public struct BaseComponentOffsets
+    {
+        // Pointer to whatever structure contains these data.
+        [FieldOffset(0x10)] public long ItemCellsPtr;
+
+        [FieldOffset(0xDC)] public byte InfluenceFlag;
+        // This is incorrect, and I can't figure out the correct
+        // offset at this time.  I suspect that the C++ code has
+        // either (a) changed to use a value other than "1" for true,
+        // or (b) this data is now stored elsewhere in the item struct.
+        [FieldOffset(0xDF)] public bool isCorrupted;
+        [FieldOffset(0xE2)] public bool isSynthesized;
+        [FieldOffset(0x64)] public long PublicPricePtr;
+    }
+}

--- a/GameOffsets/GameOffsets.csproj
+++ b/GameOffsets/GameOffsets.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -39,6 +39,7 @@
     <Compile Include="ActionWrapperOffsets.cs" />
     <Compile Include="ActorComponentOffsets.cs" />
     <Compile Include="ActorDeployedObject.cs" />
+    <Compile Include="BaseComponentOffsets.cs" />
     <Compile Include="BuffOffsets.cs" />
     <Compile Include="BuffStringOffsets.cs" />
     <Compile Include="CameraOffsets.cs" />


### PR DESCRIPTION
Move Base component data to use a struct for reading, not one-byte
remote reads.  Not a huge performance improvement, but not terrible,
given the frequency of access.

Found the correct offset for the influence flags, and verified it with
a range of influenced and non-influenced items.

Sadly, I failed to find the correct offset for the corrupted flag before
running out of patience.  Added a comment about what I found.
