### PR TITLE
Fix mouseLocation and UIHover offsets

### DIFF
--- a/GameOffsets/IngameStateOffsets.cs
+++ b/GameOffsets/IngameStateOffsets.cs
@@ -10,16 +10,16 @@ namespace GameOffsets
 	    [FieldOffset(0x30)] public long Data;
 	    [FieldOffset(0x418)] public long ServerData;
 	    [FieldOffset(0x540)] public long UIRoot;
-	    [FieldOffset(0x668)] public long UIHoverTooltip;
+	    [FieldOffset(0x58C)] public long UIHoverTooltip; //if this is a memory region, that tells if ANY tooltip is shown on the screen, then this offset is correct
 	    [FieldOffset(0x670)] public float CurentUElementPosX;
 	    [FieldOffset(0x674)] public float CurentUElementPosY;
-	    [FieldOffset(0x678)] public long UIHover;
-	    [FieldOffset(0x6A0)] public int MouseXGlobal;
-	    [FieldOffset(0x6A4)] public int MouseYGlobal;
+	    [FieldOffset(0x578)] public long UIHover; //if this one is for telling different hovered objects, then offset is correct
+	    [FieldOffset(0x5B0)] public int MouseXGlobal;
+	    [FieldOffset(0x5B4)] public int MouseYGlobal;
 	    [FieldOffset(0x6AC)] public float UIHoverX;
 	    [FieldOffset(0x6B0)] public float UIHoverY;
-	    [FieldOffset(0x6B4)] public float MouseXInGame;
-	    [FieldOffset(0x6B8)] public float MouseYInGame;
+	    [FieldOffset(0x1418)] public float MouseXInGame; //these (mouse X and Y) offsets are actually far before the InGameState memory, but this is also some kind of memory that shows mouse location = same as global.
+	    [FieldOffset(0x141C)] public float MouseYInGame;
 	    [FieldOffset(0x5EC)] public float TimeInGame;
 	    [FieldOffset(0x5F4)] public float TimeInGameF;
 	    [FieldOffset(0x6F8)] public int DiagnosticInfoType;


### PR DESCRIPTION
Fixed the offsets for mouseLocation and UIHover. Mouse location offsets might not be entirely correct, but these ones are the only ones that are remotely close to InGameState memory. They tell the same values, but have different addresses.
UIHover is definitely correct, as MapNotify plugin started working, and DevTree also shows correct info now. Im just guessing what UIHowerTooltip means.
This is my first time working with offsets and game memory, and I'm starting to get a grasp of it.