### PR TITLE
Fix item-heavy map

### DIFF
--- a/Core/PoEMemory/Elements/ItemsOnGroundLabelElement.cs
+++ b/Core/PoEMemory/Elements/ItemsOnGroundLabelElement.cs
@@ -50,7 +50,7 @@ namespace ExileCore.PoEMemory.Elements
 
                     limit++;
 
-                    if (limit > 1000)
+                    if (limit > 100000)
                         return null;
                 }
 


### PR DESCRIPTION
100% delirium was breaking PickIt due to the sole amount of items on the ground.