### PR TITLE
Fix offset for VaalSkill names

### DIFF
--- a/Core/PoEMemory/MemoryObjects/ActorVaalSkill.cs
+++ b/Core/PoEMemory/MemoryObjects/ActorVaalSkill.cs
@@ -2,7 +2,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
 {
     public class ActorVaalSkill : RemoteMemoryObject
     {
-        private const int NAMES_POINTER_OFFSET = 0x8;
+        private const int NAMES_POINTER_OFFSET = 0x0;
         private const int INTERNAL_NAME_OFFSET = 0x0;
         private const int NAME_OFFSET = 0x8;
         private const int DESCRIPTION_OFFSET = 0x10;


### PR DESCRIPTION
This fixes ActorVaalSkill to have proper name values.