### PR TITLE
rollback MinimapIcon.cs

### DIFF
--- a/Core/PoEMemory/Components/MinimapIcon.cs
+++ b/Core/PoEMemory/Components/MinimapIcon.cs
@@ -12,7 +12,9 @@ namespace ExileCore.PoEMemory.Components
         private MinimapIconOffsets MinimapIconOffsets => cachedValue.Value;
         public bool IsVisible => MinimapIconOffsets.IsVisible == 0; //M.Read<byte>(Address + 0x30) == 0;
         public bool IsHide => MinimapIconOffsets.IsHide == 1; //M.Read<byte>(Address + 0x34) == 1;
-        public string Name => NativeStringReader.ReadString(MinimapIconOffsets.NamePtr, M); 
+        private NativeStringU Test => M.Read<NativeStringU>(MinimapIconOffsets.NamePtr); //M.Read<NativeStringU>(Address + 0x20, 0);
+        public string TestString => Test.ToString(M);
+        public string Name => Cache.StringCache.Read($"{MinimapIconOffsets.NamePtr}{Address}", () => TestString);
         protected override void OnAddressChange() 
         {
             cachedValue = new FrameCache<MinimapIconOffsets>(() => M.Read<MinimapIconOffsets>(Address));


### PR DESCRIPTION
MinimapIconOffsets =>[FieldOffset (0x20)] public long NamePtr; turned out to be correct, but
  after the last changes (it seems because of the entity_list / entity) on some icons, in particular on 
  Metadata / MiscellaneousObjects / Heist / HeistStash_Hideout: my update began to read garbage.
Your old method returning an empty string - that's better.
Sorry