### PR TITLE
BroodyHen support, Offsets, and more reference swaps.

### DIFF
--- a/Core/PoEMemory/Components/Mods.cs
+++ b/Core/PoEMemory/Components/Mods.cs
@@ -32,6 +32,8 @@ namespace ExileCore.PoEMemory.Components
         public int RequiredLevel => Address != 0 ? ModsStruct.RequiredLevel : 1;
         public bool IsUsable => Address != 0 && ModsStruct.IsUsable == 1;
         public bool IsMirrored => Address != 0 && ModsStruct.IsMirrored == 1;
+        public string IncubatorName => Address != 0 && ModsStruct.IncubatorKey != 0
+            ? M.ReadStringU(M.Read<long>(ModsStruct.IncubatorKey, 0x20)) : null;
 
         public int FracturedCount => (int) ModsStruct.GetFracturedStats.Size / ModsComponentOffsets.StatRecordSize;
         public bool IsFractured => FracturedCount > 0;

--- a/Core/PoEMemory/MemoryObjects/GrantedEffectsPerLevel.cs
+++ b/Core/PoEMemory/MemoryObjects/GrantedEffectsPerLevel.cs
@@ -8,14 +8,39 @@ namespace ExileCore.PoEMemory.MemoryObjects
     {
         public SkillGemWrapper SkillGemWrapper => ReadObject<SkillGemWrapper>(Address);
         public int Level => M.Read<int>(Address + 0x10);
-        public int RequiredLevel => M.Read<int>(Address + 0x74);
-        public int ManaMultiplier => M.Read<int>(Address + 0x78);
+        public int RequiredLevel => M.Read<int>(Address + 0x7C);
+        public int ManaMultiplier => M.Read<int>(Address + 0x80);
 
-        //public int RequirementsComparer => M.Read<int>(Address + 0x80);
-        public int ManaCost => M.Read<int>(Address + 0xa8);
-        public int EffectivenessOfAddedDamage => M.Read<int>(Address + 0xac);
-        public int Cooldown => M.Read<int>(Address + 0xb4);
+        //public int RequirementsComparer => M.Read<int>(Address + 0x84);
 
+        public int EffectivenessOfAddedDamage => M.Read<int>(Address + 0x90);
+        public int Cooldown => M.Read<int>(Address + 0x98);
+
+        public IEnumerable<Tuple<StatsDat.StatRecord, int>> Costs
+        {
+            get
+            {
+                var result = new List<Tuple<StatsDat.StatRecord, int>>();
+
+                var costsCount = M.Read<int>(Address + 0xF1);
+                var pointerToTypes = M.Read<long>(Address + 0x109);
+                var pointerToValues = M.Read<long>(Address + 0xF9);
+
+                for (var i = 0; i < costsCount; i++)
+                {
+                    var statAddress = M.Read<long>(pointerToTypes, 0x08);
+                    var stat = TheGame.Files.Stats.GetStatByAddress(statAddress);
+                    var value = M.Read<int>(pointerToValues);
+
+                    result.Add(new Tuple<StatsDat.StatRecord, int>(stat, value));
+
+                    pointerToTypes += 16;
+                    pointerToValues += 8;
+                }
+
+                return result;
+            }
+        }
         public IEnumerable<Tuple<StatsDat.StatRecord, int>> Stats
         {
             get
@@ -24,8 +49,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
 
                 var statsCount = M.Read<int>(Address + 0x14);
                 var pointerToStats = M.Read<long>(Address + 0x1c);
-                pointerToStats += 8;
-
+                
                 for (var i = 0; i < statsCount; i++)
                 {
                     var datPtr = M.Read<long>(pointerToStats);
@@ -38,80 +62,21 @@ namespace ExileCore.PoEMemory.MemoryObjects
             }
         }
 
-        public IEnumerable<string> Tags
-        {
-            get
-            {
-                var result = new List<string>();
-
-                var tagsCount = M.Read<int>(Address + 0x44);
-                var pointerToTags = M.Read<long>(Address + 0x4c);
-                pointerToTags += 8;
-
-                for (var i = 0; i < tagsCount; i++)
-                {
-                    var tagStringPtr = M.Read<long>(pointerToTags);
-                    tagStringPtr = M.Read<long>(tagStringPtr);
-                    result.Add(M.ReadStringU(tagStringPtr));
-                    pointerToTags += 16; //16 because we are reading each second pointer
-                }
-
-                return result;
-            }
-        }
-
-        public IEnumerable<Tuple<StatsDat.StatRecord, int>> QualityStats
-        {
-            get
-            {
-                var result = new List<Tuple<StatsDat.StatRecord, int>>();
-
-                var statsCount = M.Read<int>(Address + 0x84);
-                var pointerToStats = M.Read<long>(Address + 0x8c);
-                pointerToStats += 8; //Skip first
-
-                for (var i = 0; i < statsCount; i++)
-                {
-                    var datPtr = M.Read<long>(pointerToStats);
-                    var stat = TheGame.Files.Stats.GetStatByAddress(datPtr);
-                    result.Add(new Tuple<StatsDat.StatRecord, int>(stat, ReadQualityStatValue(i)));
-                    pointerToStats += 16; //16 because we are reading each second pointer
-                }
-
-                return result;
-            }
-        }
-
-        public IEnumerable<StatsDat.StatRecord> TypeStats
-        {
-            get
-            {
-                var result = new List<StatsDat.StatRecord>();
-
-                var statsCount = M.Read<int>(Address + 0xbc);
-                var pointerToStats = M.Read<long>(Address + 0xc4);
-                pointerToStats += 8; //Skip first
-
-                for (var i = 0; i < statsCount; i++)
-                {
-                    var datPtr = M.Read<long>(pointerToStats);
-                    var stat = TheGame.Files.Stats.GetStatByAddress(datPtr);
-                    result.Add(stat);
-                    pointerToStats += 16; //16 because we are reading each second pointer
-                }
-
-                return result;
-            }
-        }
-
         internal int ReadStatValue(int index)
         {
-            return M.Read<int>(Address + 0x54 + index * 4);
+            return M.Read<int>(Address + 0x58 + index * 4);
         }
 
-        internal int ReadQualityStatValue(int index)
-        {
-            return M.Read<int>(Address + 0x9c + index * 4);
-        }
+        [Obsolete("No longer exists as of 3.14. See the Cost property.", false)]
+        public int ManaCost => 0;
+
+        [Obsolete("No longer exists as of 3.14.", false)]
+        public IEnumerable<string> Tags => new List<string>();
+
+        [Obsolete("No longer exists as of 3.14.", false)]
+        public IEnumerable<Tuple<StatsDat.StatRecord, int>> QualityStats => new List<Tuple<StatsDat.StatRecord, int>>();
+
+        [Obsolete("No longer exists as of 3.14.", false)]
+        public IEnumerable<StatsDat.StatRecord> TypeStats => new List<StatsDat.StatRecord>();
     }
 }

--- a/Core/PoEMemory/MemoryObjects/GrantedEffectsPerLevel.cs
+++ b/Core/PoEMemory/MemoryObjects/GrantedEffectsPerLevel.cs
@@ -35,7 +35,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
                     result.Add(new Tuple<StatsDat.StatRecord, int>(stat, value));
 
                     pointerToTypes += 16;
-                    pointerToValues += 8;
+                    pointerToValues += 4;
                 }
 
                 return result;

--- a/GameOffsets/ActorComponentOffsets.cs
+++ b/GameOffsets/ActorComponentOffsets.cs
@@ -15,7 +15,7 @@ namespace GameOffsets
         // [FieldOffset(0x100)] public float TotalTimeInAction;
         // some unknown timer whos value keep resetting to zero.
         // [FieldOffset(0x104)] public float UnknownTimer;
-        [FieldOffset(0x230)] public int AnimationId;
+        [FieldOffset(0x234)] public int AnimationId;
 
         // Use the one inside the ActionPtr struct (i.e. ActionWrapperOffsets).
         // That one works for all kind of skills.

--- a/GameOffsets/ModsComponentOffsets.cs
+++ b/GameOffsets/ModsComponentOffsets.cs
@@ -25,6 +25,7 @@ namespace GameOffsets
         [FieldOffset(0x260)] public NativePtrArray GetSynthesizedStats;
         [FieldOffset(0x48C)] public int ItemLevel;
         [FieldOffset(0x490)] public int RequiredLevel;
+        [FieldOffset(0x498)] public long IncubatorKey;
         [FieldOffset(0x47C)] public byte IsUsable;
         [FieldOffset(0x47D)] public byte IsMirrored;
     }


### PR DESCRIPTION
BroodyHen requires incubator name, which GGG added incubator information to the end of the mods component. It matches what  I believe the private hud is doing. Should probably look at the incubator offset to see if anything else is worth exposing.