### PR TITLE
Fixed issue with IsDead returning incorrect value

### DIFF
--- a/Core/PoEMemory/MemoryObjects/Entity.cs
+++ b/Core/PoEMemory/MemoryObjects/Entity.cs
@@ -222,7 +222,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
                 if (!IsValid)
                     return _isDead;
 
-                _isDead = !_isAlive;
+                _isDead = !IsAlive;
                 return _isDead;
             }
         }


### PR DESCRIPTION
Current implementation of IsDead just negates the value of private boolean _isAlive. If IsDead is accessed before IsAlive, _isAlive would be set to the default boolean value of false causing IsDead to return true incorrectly in some cases. 

