### PR TITLE
Feature support and bugfixes.

### DIFF
--- a/Core/PoEMemory/Components/Mods.cs
+++ b/Core/PoEMemory/Components/Mods.cs
@@ -35,6 +35,7 @@ namespace ExileCore.PoEMemory.Components
         public bool IsSplit => Address != 0 && ModsStruct.IsSplit == 1;
         public string IncubatorName => Address != 0 && ModsStruct.IncubatorKey != 0
             ? M.ReadStringU(M.Read<long>(ModsStruct.IncubatorKey, 0x20)) : null;
+        public short IncubatorKills => ModsStruct.IncubatorKillCount;
 
         public List<ItemMod> ItemMods
         {
@@ -60,7 +61,7 @@ namespace ExileCore.PoEMemory.Components
         public bool IsTalisman => ItemMods != null &&
                                   ItemMods.Any(x => x.RawName.StartsWith("Talisman"));
         public int TalismanCount => IsTalisman ? HumanImpStats.Count : 0;
-        public int VeiledCount => ItemMods?.Count(x => x.RawName.StartsWith("Veiled")) ?? 0;
+        public int VeiledCount => ItemMods?.Count(x => x.Group.StartsWith("Veiled")) ?? 0;
         public bool IsVeiled => VeiledCount > 0;
         
         private string GetUniqueName(NativePtrArray source)

--- a/Core/PoEMemory/Elements/InventoryElement.cs
+++ b/Core/PoEMemory/Elements/InventoryElement.cs
@@ -53,6 +53,8 @@ namespace ExileCore.PoEMemory.Elements
                     return EquippedItems.GetChildAtIndex(18);
                 case InventoryIndex.Flask:
                     return EquippedItems.GetChildAtIndex(17);
+                case InventoryIndex.Trinket:
+                    return EquippedItems.GetChildAtIndex(19);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(inventoryIndex));
             }

--- a/Core/PoEMemory/MemoryObjects/ActorSkill.cs
+++ b/Core/PoEMemory/MemoryObjects/ActorSkill.cs
@@ -18,7 +18,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public GrantedEffectsPerLevel EffectsPerLevel => ReadObject<GrantedEffectsPerLevel>(Address + 0x18);
         public bool CanBeUsedWithWeapon => M.Read<byte>(Address + 0x50) > 0; 
         public bool CanBeUsed => M.Read<byte>(Address + 0x51) == 0;
-        public int TotalUses => M.Read<int>(Address + 0x58); 
+        public int TotalUses => M.Read<int>(Address + 0x54); 
         public float Cooldown => M.Read<int>(Address + 0x5C) / 100f; //Converted milliseconds to seconds 
         public int SoulsPerUse => M.Read<int>(Address + 0x6C);
         public int TotalVaalUses => M.Read<int>(Address + 0x70);

--- a/Core/PoEMemory/MemoryObjects/ActorSkill.cs
+++ b/Core/PoEMemory/MemoryObjects/ActorSkill.cs
@@ -18,7 +18,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public GrantedEffectsPerLevel EffectsPerLevel => ReadObject<GrantedEffectsPerLevel>(Address + 0x18);
         public bool CanBeUsedWithWeapon => M.Read<byte>(Address + 0x50) > 0; 
         public bool CanBeUsed => M.Read<byte>(Address + 0x51) == 0;
-        public int TotalUses => M.Read<int>(Address + 0x54); 
+        public int TotalUses => M.Read<int>(Address + 0x58); 
         public float Cooldown => M.Read<int>(Address + 0x5C) / 100f; //Converted milliseconds to seconds 
         public int SoulsPerUse => M.Read<int>(Address + 0x6C);
         public int TotalVaalUses => M.Read<int>(Address + 0x70);

--- a/Core/PoEMemory/MemoryObjects/ActorVaalSkill.cs
+++ b/Core/PoEMemory/MemoryObjects/ActorVaalSkill.cs
@@ -19,5 +19,10 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public int VaalMaxSouls => M.Read<int>(Address + MAX_VAAL_SOULS_OFFSET);
         public int VaalSoulsPerUse => M.Read<int>(Address + VAAL_SOULS_PER_USE_OFFSET);
         public int CurrVaalSouls => M.Read<int>(Address + CURRENT_VAAL_SOULS_OFFSET);
+
+        public override string ToString()
+        {
+            return VaalSkillDisplayName;
+        }
     }
 }

--- a/Core/PoEMemory/MemoryObjects/IngameUIElements.cs
+++ b/Core/PoEMemory/MemoryObjects/IngameUIElements.cs
@@ -65,6 +65,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public Element Sulphit => GetObject<Element>(IngameUIElementsStruct.Map).GetChildAtIndex(0);
         public Cursor Cursor => _cursor ??= GetObject<Cursor>(IngameUIElementsStruct.Mouse);
         public Element BetrayalWindow => _BetrayalWindow ??= GetObject<Element>(IngameUIElementsStruct.BetrayalWindow);
+        public Element SyndicatePanel => BetrayalWindow; // Required for TehCheats Api, BroodyHen uses this.
         public Element SyndicateTree => GetObject<Element>(M.Read<long>(BetrayalWindow.Address + 0xA50));
         public Element UnveilWindow => _UnveilWindow ??= GetObject<Element>(IngameUIElementsStruct.UnveilWindow);
         public Element ZanaMissionChoice => _ZanaMissionChoice ??= GetObject<Element>(IngameUIElementsStruct.ZanaMissionChoice);
@@ -77,9 +78,11 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public WorldMapElement WorldMap => GetObject<WorldMapElement>(IngameUIElementsStruct.WorldMap);
         public MetamorphWindowElement MetamorphWindow => GetObject<MetamorphWindowElement>(IngameUIElementsStruct.MetamorphWindow);
         public RitualWindow RitualWindow => GetObject<RitualWindow>(IngameUIElementsStruct.RitualWindow);
+        public Element RitualFavourWindow => GetObject<Element>(IngameUIElementsStruct.RitualFavourPanel);
+        public Element UltimatumProgressWindow => GetObject<Element>(IngameUIElementsStruct.UltimatumProgressPanel);
         public DelveDarknessElement DelveDarkness => GetObject<DelveDarknessElement>(IngameUIElementsStruct.DelveDarkness);
         public HarvestWindow HarvestWindow => GetObject<HarvestWindow>(IngameUIElementsStruct.HarvestWindow);
-
+        
         public IEnumerable<QuestState> GetUncompletedQuests => GetQuestStates.Where(q => q.QuestStateId != 0);
         public IEnumerable<QuestState> GetCompletedQuests => GetQuestStates.Where(q => q.QuestStateId == 0);
         public List<QuestState> GetQuestStates => _cachedQuestStates?.Value;

--- a/Core/PoEMemory/MemoryObjects/InventoryList.cs
+++ b/Core/PoEMemory/MemoryObjects/InventoryList.cs
@@ -6,7 +6,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
 {
     public class InventoryList : RemoteMemoryObject
     {
-        public static int InventoryCount => 15;
+        public static int InventoryCount => 37;
 
         public Inventory this[InventoryIndex inv]
         {
@@ -27,13 +27,8 @@ namespace ExileCore.PoEMemory.MemoryObjects
         {
             var list = new List<Inventory>();
 
-            foreach (var inx in Enum.GetValues(typeof(InventoryIndex)))
+            for (var num = 0; num < InventoryCount; ++num)
             {
-                var num = (int) inx;
-
-                if (num < 0 || num >= InventoryCount)
-                    return null;
-
                 list.Add(ReadObjectAt<Inventory>(num * 8));
             }
 

--- a/Core/Shared/Enums/InventoryIndex.cs
+++ b/Core/Shared/Enums/InventoryIndex.cs
@@ -16,9 +16,28 @@ namespace ExileCore.Shared.Enums
         Belt,
         Boots,
         PlayerInventory,
-        Flask
-
-        //Stash1 = 24,
-        //Stash2
+        Flask,
+        Trinket,
+        LWeaponSkin,
+        LWeaponEffect,
+        LWeaponAddedEffect,
+        RWeaponSkin,
+        RWeaponEffect,
+        RWeaponAddedEffect,
+        HelmSkin,
+        HelmAttachment1,
+        BodySkin,
+        BodyAttachment,
+        GlovesSkin,
+        BootsSkin,
+        Footprints,
+        Apparition,
+        CharacterEffect,
+        Portrait,
+        PortraitFrame,
+        Pet1,
+        Pet2,
+        Portal,
+        HelmAttachment2
     }
 }

--- a/Core/Shared/Enums/InventorySlotE.cs
+++ b/Core/Shared/Enums/InventorySlotE.cs
@@ -47,7 +47,7 @@ namespace ExileCore.Shared.Enums
         MetamorphConstruct,
         AtlasWatchtower,
         AtlasTray,
-        Harvest1, // TODO: Check inventory items to see if Harvest enums are actually Harvest
+        Harvest1,
         Harvest2,
         Harvest3,
         HeistBlueprint,
@@ -63,6 +63,15 @@ namespace ExileCore.Shared.Enums
         Trinket1,
         HeistBlueprintPlanner,
         GrandHeist,
-        HeistLocker
+        HeistLocker,
+        Unknown58,
+        Unknown59,
+        Unknown60,
+        Unknown61,
+        Unknown62,
+        Unknown63,
+        Unknown64,
+        Unknown65,
+        UltimatumSacrifice
     }
 }

--- a/Core/Shared/Enums/InventoryTypeE.cs
+++ b/Core/Shared/Enums/InventoryTypeE.cs
@@ -35,7 +35,7 @@ namespace ExileCore.Shared.Enums
         CraftingSpreeItem,
         NormalOrQuad,
         AtlasWatchtower,
-        Harvest1, // TODO: Check inventory items to see if Harvest enums are actually Harvest
+        Harvest1,
         Unknown30, // TODO: Check if these are 3.11 3-pack league tabs
         Unknown31,
         Harvest2,
@@ -43,6 +43,13 @@ namespace ExileCore.Shared.Enums
         HeistAllyEquipment,
         Trinket,
         HeistLocker,
-        StashRegularTab
+        StashRegularTab,
+        Unknown38,
+        Unknown39,
+        Unknown40,
+        Unknown41,
+        Unknown42,
+        Unknown43,
+        UtzaalUltimatum
     }
 }

--- a/GameOffsets/IngameUElementsOffsets.cs
+++ b/GameOffsets/IngameUElementsOffsets.cs
@@ -38,6 +38,8 @@ namespace GameOffsets
         [FieldOffset(0x7A0)] public long MetamorphWindow;
         [FieldOffset(0x7B0)] public long HarvestWindow;
         [FieldOffset(0x7E8)] public long RitualWindow;
+        [FieldOffset(0x7F0)] public long RitualFavourPanel;
+        [FieldOffset(0x7F8)] public long UltimatumProgressPanel;
         [FieldOffset(0x848)] public long DelveDarkness;
         [FieldOffset(0x858)] public long AreaInstanceUi;
         [FieldOffset(0x950)] public long InvitesPanel;
@@ -161,7 +163,7 @@ namespace GameOffsets
         //[FieldOffset(0x7E0)] public long HeistLockerPanel;
         //[FieldOffset(0x7E8)] public long RitualWindow;
         //[FieldOffset(0x7F0)] public long RitualFavourPanel;
-        //[FieldOffset(0x7F8)] public long UltimatumPanel;
+        //[FieldOffset(0x7F8)] public long UltimatumProgressPanel;
         //[FieldOffset(0x800)] public long UI[25][10];
 
         //[FieldOffset(0x820)] public long UI[24]; Guild Perms

--- a/GameOffsets/ModsComponentOffsets.cs
+++ b/GameOffsets/ModsComponentOffsets.cs
@@ -27,6 +27,7 @@ namespace GameOffsets
         [FieldOffset(0x48C)] public int ItemLevel;
         [FieldOffset(0x490)] public int RequiredLevel;
         [FieldOffset(0x498)] public long IncubatorKey;
+        [FieldOffset(0x4A8)] public short IncubatorKillCount;
         [FieldOffset(0x4AC)] public byte IsUsable;
     }
 }


### PR DESCRIPTION
- VaalActorSkills now has a ToString function instead of displaying as an address.
- Added Trinket support as well as extending the full InventoryIndex list.
- Ritual Favour Element added. Note: Will always be visible as GGG opted to use transparency to hide the panel.
- Ultimatum Progress Element added. Note: You can find the start panel in the Entity List. This is panel the shows between waves.
- BroodyHen support. TC's hud refers to SyndicatePanel. Added Incubator Kills to the mod component.
- ~~Fixed offset that became broken in ActorSkill.~~
- Fixed bug where the watchstone prefix "Veiled" would trigger whenever we were searching for Veiled affixes.