### PR TITLE
More offsets and new component.

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -209,6 +209,7 @@
     <Compile Include="PoEMemory\Components\HeistBlueprint.cs" />
     <Compile Include="PoEMemory\Components\HeistContract.cs" />
     <Compile Include="PoEMemory\Components\HeistEquipment.cs" />
+    <Compile Include="PoEMemory\Components\HeistRewardDisplay.cs" />
     <Compile Include="PoEMemory\Components\HideoutDoodad.cs" />
     <Compile Include="PoEMemory\Components\Inventories.cs" />
     <Compile Include="PoEMemory\Components\InventoryVisual.cs" />

--- a/Core/PoEMemory/Components/HeistRewardDisplay.cs
+++ b/Core/PoEMemory/Components/HeistRewardDisplay.cs
@@ -1,0 +1,13 @@
+﻿using ExileCore.PoEMemory.MemoryObjects;
+using ExileCore.Shared.Enums;
+using ExileCore.Shared.Helpers;
+using GameOffsets.Native;
+using GameOffsets;
+using ExileCore.Shared.Cache;
+
+namespace ExileCore.PoEMemory.Components
+{
+    public class HeistRewardDisplay: Component
+    {
+    }
+}

--- a/Core/PoEMemory/Element.cs
+++ b/Core/PoEMemory/Element.cs
@@ -30,7 +30,7 @@ namespace ExileCore.PoEMemory
 
         public Element()
         {
-            _cacheElement = new FrameCache<ElementOffsets>(() => Address != 0 ? default : M.Read<ElementOffsets>(Address));
+            _cacheElement = new FrameCache<ElementOffsets>(() => Address == 0 ? default : M.Read<ElementOffsets>(Address));
             _cacheElementIsVisibleLocal = new FrameCache<bool>(() => Address != 0 && M.Read<bool>(Address + IsVisibleLocalOff));
         }
 
@@ -103,7 +103,9 @@ namespace ExileCore.PoEMemory
             var pointers = M.ReadPointersArray(e.ChildStart, e.ChildEnd);
 
             if (pointers.Count != ChildCount) return _childrens;
-            _childrens.AddRange(pointers.Select(GetObject<Element>).ToList()); 
+            _childrens.Clear();
+
+            _childrens.AddRange(pointers.Select(GetObject<Element>).ToList());
             childHashCache = ChildHash;
             return _childrens;
         }
@@ -205,24 +207,24 @@ namespace ExileCore.PoEMemory
         {
             return index >= ChildCount ? null : GetObject<Element>(M.Read<long>(Address + ChildStartOffset, index * 8));
         }
-
-        public void GetAllStrings(List<string> res) {
-            if(Text?.Length > 0) {
+        public void GetAllStrings(List<string> res)
+        {
+            if (Text?.Length > 0)
+            {
                 res.Add(Text);
             }
-            foreach(var ch in Children)
+            foreach (var ch in Children)
                 ch.GetAllStrings(res);
         }
-
-        public void GetAllTextElements(List<Element> res) {
-            if(Text?.Length > 0) {
+        public void GetAllTextElements(List<Element> res)
+        {
+            if (Text?.Length > 0)
+            {
                 res.Add(this);
             }
-
-            foreach(var ch in Children)
+            foreach (var ch in Children)
                 ch.GetAllTextElements(res);
         }
-
         public Element GetElementByString(string str)
         {
             return Text == str ? this : Children.Select(child => child.GetElementByString(str)).FirstOrDefault(element => element != null);

--- a/Core/PoEMemory/Element.cs
+++ b/Core/PoEMemory/Element.cs
@@ -25,14 +25,13 @@ namespace ExileCore.PoEMemory
         private readonly List<Element> _childrens = new List<Element>();
         private CachedValue<RectangleF> _getClientRect;
 
-        // public Element Root => Elem.Root==0 ?null: GetObject<Element>(M.Read<long>(Elem.Root+0xE8));
         private Element _parent;
         private long childHashCache;
 
         public Element()
         {
-            _cacheElement = new FrameCache<ElementOffsets>(() => Address == 0 ? default : M.Read<ElementOffsets>(Address));
-            _cacheElementIsVisibleLocal = new FrameCache<bool>(() => Address == 0 ? default : M.Read<bool>(Address + IsVisibleLocalOff));
+            _cacheElement = new FrameCache<ElementOffsets>(() => Address != 0 ? default : M.Read<ElementOffsets>(Address));
+            _cacheElementIsVisibleLocal = new FrameCache<bool>(() => Address != 0 && M.Read<bool>(Address + IsVisibleLocalOff));
         }
 
         public ElementOffsets Elem => _cacheElement.Value;
@@ -44,7 +43,7 @@ namespace ExileCore.PoEMemory
         public Vector2 Position => Elem.Position;
         public float X => Elem.X;
         public float Y => Elem.Y;
-        public Element Tooltip => Address == 0 ? null : GetObject<Element>(M.Read<long>(Address + 0x338)); //0x7F0
+        public Element Tooltip => Address == 0 ? null : GetObject<Element>(M.Read<long>(Address + 0x338));
         public float Scale => Elem.Scale;
         public float Width => Elem.Width;
         public float Height => Elem.Height;
@@ -52,13 +51,20 @@ namespace ExileCore.PoEMemory
         [Obsolete("Use IsHighlighted instead of isHighlighted, this will be removed for 3.15")] // remove this property at end of 3.14
         public bool isHighlighted => IsHighlighted;
 
+        public ColorBGRA BorderColor => new ColorBGRA(Elem.ElementBorderColor);
+        public ColorBGRA BackgroundColor => new ColorBGRA(Elem.ElementBackgroundColor);
+        public ColorBGRA OverlayColor => new ColorBGRA(Elem.ElementOverlayColor);
+
+        public ColorBGRA TextBoxBorderColor => new ColorBGRA(Elem.TextBoxBorderColor);
+        public ColorBGRA TextBoxBackgroundColor => new ColorBGRA(Elem.TextBoxBackgroundColor);
+        public ColorBGRA TextBoxOverlayColor => new ColorBGRA(Elem.TextBoxOverlayColor);
+
         public virtual string Text
         {
             get
             {
                 var text = AsObject<EntityLabel>().Text2;
-                if (!string.IsNullOrWhiteSpace(text)) return text.Replace("\u00A0\u00A0\u00A0\u00A0", "{{icon}}");
-                return null;
+                return !string.IsNullOrWhiteSpace(text) ? text.Replace("\u00A0\u00A0\u00A0\u00A0", "{{icon}}") : null;
             }
         }
 
@@ -67,8 +73,7 @@ namespace ExileCore.PoEMemory
             get
             {
                 var text = AsObject<EntityLabel>().Text3;
-                if (!string.IsNullOrWhiteSpace(text)) return text.Replace("\u00A0\u00A0\u00A0\u00A0", "{{icon}}");
-                return null;
+                return !string.IsNullOrWhiteSpace(text) ? text.Replace("\u00A0\u00A0\u00A0\u00A0", "{{icon}}") : null;
             }
         }
 
@@ -98,13 +103,7 @@ namespace ExileCore.PoEMemory
             var pointers = M.ReadPointersArray(e.ChildStart, e.ChildEnd);
 
             if (pointers.Count != ChildCount) return _childrens;
-            _childrens.Clear();
-
-            foreach (var pointer in pointers)
-            {
-                _childrens.Add(GetObject<Element>(pointer));
-            }
-
+            _childrens.AddRange(pointers.Select(GetObject<Element>).ToList()); 
             childHashCache = ChildHash;
             return _childrens;
         }
@@ -116,17 +115,7 @@ namespace ExileCore.PoEMemory
 
             var pointers = M.ReadPointersArray(e.ChildStart, e.ChildEnd);
 
-            if (pointers.Count != ChildCount)
-                return new List<T>();
-
-            var results = new List<T>();
-
-            foreach (var pointer in pointers)
-            {
-                results.Add(GetObject<T>(pointer));
-            }
-
-            return results;
+            return pointers.Count != ChildCount ? new List<T>() : pointers.Select(GetObject<T>).ToList();
         }
 
         private IList<Element> GetParentChain()
@@ -140,17 +129,14 @@ namespace ExileCore.PoEMemory
             var root = Root;
             var parent = Parent;
 
-            if (root == null || parent == null)
+            if (root == null)
                 return list;
 
-            while (!hashSet.Contains(parent) && root.Address != parent.Address && parent.Address != 0)
+            while (parent != null && !hashSet.Contains(parent) && root.Address != parent.Address && parent.Address != 0)
             {
                 list.Add(parent);
                 hashSet.Add(parent);
                 parent = parent.Parent;
-
-                if (parent == null)
-                    break;
             }
 
             return list;
@@ -189,13 +175,13 @@ namespace ExileCore.PoEMemory
 
         public Element GetChildFromIndices(params int[] indices)
         {
-            var poe_UElement = this;
+            var currentElement = this;
 
             foreach (var index in indices)
             {
-                poe_UElement = poe_UElement.GetChildAtIndex(index);
+                currentElement = currentElement.GetChildAtIndex(index);
 
-                if (poe_UElement == null)
+                if (currentElement == null)
                 {
                     var str = "";
                     indices.ForEach(i => str += $"[{i}] ");
@@ -203,7 +189,7 @@ namespace ExileCore.PoEMemory
                     return null;
                 }
 
-                if (poe_UElement.Address == 0)
+                if (currentElement.Address == 0)
                 {
                     var str = "";
                     indices.ForEach(i => str += $"[{i}] ");
@@ -212,13 +198,14 @@ namespace ExileCore.PoEMemory
                 }
             }
 
-            return poe_UElement;
+            return currentElement;
         }
 
         public Element GetChildAtIndex(int index)
         {
             return index >= ChildCount ? null : GetObject<Element>(M.Read<long>(Address + ChildStartOffset, index * 8));
         }
+
         public void GetAllStrings(List<string> res) {
             if(Text?.Length > 0) {
                 res.Add(Text);
@@ -226,22 +213,19 @@ namespace ExileCore.PoEMemory
             foreach(var ch in Children)
                 ch.GetAllStrings(res);
         }
+
         public void GetAllTextElements(List<Element> res) {
             if(Text?.Length > 0) {
                 res.Add(this);
             }
+
             foreach(var ch in Children)
                 ch.GetAllTextElements(res);
         }
-        public Element GetElementByString(string str) {
-            if(Text == str) {
-                return this;
-            }
-            foreach(var child in Children) {
-                var element = child.GetElementByString(str);
-                if(element != null) return element;
-            }
-            return null;
+
+        public Element GetElementByString(string str)
+        {
+            return Text == str ? this : Children.Select(child => child.GetElementByString(str)).FirstOrDefault(element => element != null);
         }
     }
 }

--- a/Core/PoEMemory/Elements/LabelOnGround.cs
+++ b/Core/PoEMemory/Elements/LabelOnGround.cs
@@ -13,12 +13,9 @@ namespace ExileCore.PoEMemory.Elements
         {
             labelInfo = new Lazy<long>(GetLabelInfo);
 
-            debug = new Lazy<string>(() =>
-            {
-                return ItemOnGround.HasComponent<WorldItem>()
-                    ? ItemOnGround.GetComponent<WorldItem>().ItemEntity?.GetComponent<Base>()?.Name
-                    : ItemOnGround.Path;
-            });
+            debug = new Lazy<string>(() => ItemOnGround.HasComponent<WorldItem>()
+                ? ItemOnGround.GetComponent<WorldItem>().ItemEntity?.GetComponent<Base>()?.Name
+                : ItemOnGround.Path);
         }
 
         public bool IsVisible => Label?.IsVisible ?? false;

--- a/GameOffsets/ElementOffsets.cs
+++ b/GameOffsets/ElementOffsets.cs
@@ -9,29 +9,34 @@ namespace GameOffsets
     {
         public const int OffsetBuffers = 0x6EC;
 
-        [FieldOffset(0x18)] public long SelfPointer; //Usefull for valid check
+        [FieldOffset(0x18)] public long SelfPointer; // Useful for valid check
         [FieldOffset(0x38)] public long ChildStart;
         [FieldOffset(0x38)] public NativePtrArray Childs;
         [FieldOffset(0x40)] public long ChildEnd;
-        [FieldOffset(0x111)] public byte IsVisibleLocal;
         [FieldOffset(0x88)] public long Root;
-        [FieldOffset(0x90)] public long Parent; //0x1C0 work only for items
+        [FieldOffset(0x90)] public long Parent; // Works for Items only.
         [FieldOffset(0x98)] public Vector2 Position;
         [FieldOffset(0x98)] public float X;
         [FieldOffset(0x9C)] public float Y;
-
-        [FieldOffset(0x338)] public long Tooltip;
         [FieldOffset(0x108)] public float Scale;
-        //[FieldOffset(0x11B)] public byte OverlayFillA; // Opacity switches from FF to 8c when faded
+        [FieldOffset(0x111)] public byte IsVisibleLocal;
+
+        [FieldOffset(0x110)] public uint ElementBorderColor;
+        [FieldOffset(0x114)] public uint ElementBackgroundColor;
+        [FieldOffset(0x118)] public uint ElementOverlayColor;
+
         [FieldOffset(0x130)] public float Width;
         [FieldOffset(0x134)] public float Height;
         [FieldOffset(0x178)] public bool isHighlighted; // Checks B Channel of Border (#00000000 to #E7B478FF highlighted)
-        //[FieldOffset(0x178)] public byte HighlightedBorderB;
-        //[FieldOffset(0x179)] public byte HighlightedBorderG;
-        //[FieldOffset(0x17A)] public byte HighlightedBorderR;
-        //[FieldOffset(0x17B)] public byte HighlightedBorderA;
-        //[FieldOffset(0x3CB)] public byte isShadow; //0
-        //[FieldOffset(0x3C9)] public byte isShadow2; //1
+
+        [FieldOffset(0x178)] public uint TextBoxBorderColor;
+        [FieldOffset(0x17C)] public uint TextBoxBackgroundColor;
+        [FieldOffset(0x180)] public uint TextBoxOverlayColor;
+
+        [FieldOffset(0x338)] public long Tooltip;
+
+        //[FieldOffset(0x3CB)] public byte isShadow; // 0
+        //[FieldOffset(0x3C9)] public byte isShadow2; // 1
 
         //[FieldOffset(0x3B0)] public NativeStringU TestString;
     }

--- a/GameOffsets/ServerDataOffsets.cs
+++ b/GameOffsets/ServerDataOffsets.cs
@@ -69,7 +69,9 @@ namespace GameOffsets
         [FieldOffset(0x8678 - Skip)] public ushort TradeChatChannel;
         [FieldOffset(0x8680 - Skip)] public ushort GlobalChatChannel;
         [FieldOffset(0x86D0 - Skip)] public ushort LastActionId;
-        
+
+        //[FieldOffset(0x8708 - Skip)] public long InstanceLeagueInfo;
+
         // Note: Search for a LONG value equal to your current amount of completed maps.
         //       Previous byte is a linked list of maps. Map list will be the next byte.
         [FieldOffset(0x8728 - Skip)] public long MavenMapsList;
@@ -93,7 +95,12 @@ namespace GameOffsets
         [FieldOffset(0x9228 - Skip)] public int DialogDepth;
         [FieldOffset(0x92AC - Skip)] public byte MonsterLevel;
         [FieldOffset(0x92AD - Skip)] public byte MonstersRemaining;
+        //[FieldOffset(0x9328 - Skip)] public long LeftIncursionArchitectKey;
+        //[FieldOffset(0x9338 - Skip)] public long RightIncursionArchitectKey;
         [FieldOffset(0x9358 - Skip)] public int CurrentAzuriteAmount;
         [FieldOffset(0x9368 - Skip)] public ushort CurrentSulphiteAmount;
+
+        //[FieldOffset(0x9590 - Skip)] public long DeliriumRewardInfo;
+        //[FieldOffset(0x95A8 - Skip)] public long BlueprintRevealInfo;
     }
 }


### PR DESCRIPTION
1. Implemented `HeistRewardDisplay` component. This is a component of the curio displays holding contract targets and blueprint rewards. Has information about the Heist instance and stages of the curio display cracks, stuff nobody really cares about?
2. Exposed the various color attributes of an `Element`. `Element.IsHighlighted` makes assumptions about the color scheme of objects that may be true with UI panels but not necessarily true with labels on the ground (e.g. lootfilters) or icons (e.g. Heist Reward Room Chests).
3. Commented into the ServerDataOffsets some interesting offsets related to league information. 0x8708 InstanceLeagueInfo is an array of objects for each league mechanic being tracked. As an example, when the LeagueID is 0x72, the layout of the data is for Ultimatum. 

```
0008 Byte                 League ID
0170 Byte                 Current Wave
0174 Bool                 Encounter State - Inactive, Active, Paused, Completed, Failed
0178 KeyFilePair          Ultimatum Encounter Key - Protect the Altar, Survive, Stand In Circles, etc.
0190 KeyFilePairArray     Applied Ultimatum Modifiers
01A8 KeyFilePairArray     Ultimatum Modifier Choices (3)
01E0 Byte                 Current Index Choice
01E4 Bool                 Was User Selected
```

I've just started playing with this, so I haven't even explored everything included in Ultimatum (items?) or which leagues get tracked. Delirium is internally called Affliction and their are different IDs for the Delirium Source (0x68 is a Map with Delirious layers, 0x66 is random Delirium encounter). Delirium data tracked includes the reward type, number of reward stacks reached, and possibly kill data related to levels (can't remember atm).