### PR TITLE
Fix a type casting issue in Reservations

### DIFF
--- a/Core/PoEMemory/Components/Life.cs
+++ b/Core/PoEMemory/Components/Life.cs
@@ -21,12 +21,12 @@ namespace ExileCore.PoEMemory.Components
         private LifeComponentOffsets LifeComponentOffsetsStruct => _life.Value;
         public int MaxHP => Address != 0 ? LifeComponentOffsetsStruct.MaxHP : 1;
         public int CurHP => Address != 0 ? LifeComponentOffsetsStruct.CurHP : 0;
-        public double ReservedPercentHP => LifeComponentOffsetsStruct.ReservedPercentHP / 100;
-        public int ReservedFlatHP => (int)(MaxHP * ReservedPercentHP / 100);
+        public double ReservedPercentHP => LifeComponentOffsetsStruct.ReservedPercentHP / 100d;
+        public int ReservedFlatHP => (int)Math.Round(MaxHP * ReservedPercentHP / 100);
         public int MaxMana => Address != 0 ? LifeComponentOffsetsStruct.MaxMana : 1;
         public int CurMana => Address != 0 ? LifeComponentOffsetsStruct.CurMana : 1;
-        public double ReservedPercentMana => LifeComponentOffsetsStruct.ReservedPercentMana / 100;
-        public int ReservedFlatMana => (int)(MaxMana * ReservedPercentMana / 100);
+        public double ReservedPercentMana => LifeComponentOffsetsStruct.ReservedPercentMana / 100d;
+        public int ReservedFlatMana => (int)Math.Round(MaxMana * ReservedPercentMana / 100);
         public int MaxES => LifeComponentOffsetsStruct.MaxES;
         public int CurES => LifeComponentOffsetsStruct.CurES;
         public float HPPercentage => CurHP / (float) (MaxHP - ReservedFlatHP);

--- a/Core/PoEMemory/MemoryObjects/ActorVaalSkill.cs
+++ b/Core/PoEMemory/MemoryObjects/ActorVaalSkill.cs
@@ -9,8 +9,8 @@ namespace ExileCore.PoEMemory.MemoryObjects
         private const int SKILL_NAME_OFFSET = 0x18;
         private const int ICON_OFFSET = 0x20;
         private const int MAX_VAAL_SOULS_OFFSET = 0x10;
-        private const int VAAL_SOULS_PER_USE_OFFSET = 0x14;
-        private const int CURRENT_VAAL_SOULS_OFFSET = 0x18;
+        private const int VAAL_SOULS_PER_USE_OFFSET = 0x14; // TODO: 0x14 is not correct here.
+        private const int CURRENT_VAAL_SOULS_OFFSET = 0x14;
         public string VaalSkillInternalName => M.ReadStringU(M.Read<long>(M.Read<long>(Address + NAMES_POINTER_OFFSET) + INTERNAL_NAME_OFFSET));
         public string VaalSkillDisplayName => M.ReadStringU(M.Read<long>(M.Read<long>(Address + NAMES_POINTER_OFFSET) + NAME_OFFSET));
         public string VaalSkillDescription => M.ReadStringU(M.Read<long>(M.Read<long>(Address + NAMES_POINTER_OFFSET) + DESCRIPTION_OFFSET));


### PR DESCRIPTION
The in-memory value for a reservation percent is like 9680 (for 96.80%), but the code is prematurely casting to int and seeing that as 96%.

Also the in-game mechanic uses a Round() to get the flat reserved number so that is added here as well.

Separately, in this pull request is a fix to the CurrVaalSouls value, it's been off for a while. The SoulsPerUse value remains wrong.