### PR TITLE
3.15 buff offsets

### DIFF
--- a/GameOffsets/BuffOffsets.cs
+++ b/GameOffsets/BuffOffsets.cs
@@ -5,11 +5,11 @@ namespace GameOffsets
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct BuffOffsets
     {
-        [FieldOffset(0x0)] public long Name;
-        [FieldOffset(0x10)] public byte IsInvisible;
-        [FieldOffset(0x11)] public byte IsRemovable;
-        [FieldOffset(0x36)] public byte Charges;
-        [FieldOffset(0x10)] public float MaxTime;
-        [FieldOffset(0x14)] public float Timer;
+        [FieldOffset(0x8)] public long Name;
+        [FieldOffset(0x18)] public byte IsInvisible;
+        [FieldOffset(0x19)] public byte IsRemovable;
+        [FieldOffset(0x3E)] public byte Charges;
+        [FieldOffset(0x18)] public float MaxTime;
+        [FieldOffset(0x1C)] public float Timer;
     }
 }


### PR DESCRIPTION
Buff offsets for Expedition league. This prevents BasicFlaskRoutine from spamming flasks because it can't detect player buffs.

Credits to @zaafar 