### PR TITLE
Update EntityLabel.cs

### DIFF
--- a/Core/PoEMemory/Elements/EntityLabel.cs
+++ b/Core/PoEMemory/Elements/EntityLabel.cs
@@ -46,8 +46,8 @@ namespace ExileCore.PoEMemory.Elements
             }
         }
 
-        public string Text2 => NativeStringReader.ReadString(Address + 0x2E8, M);
+        public string Text2 => NativeStringReader.ReadString(Address + 0x2E8+8, M);
 
-        public string Text3 => NativeStringReader.ReadStringLong(Address + 0x2E8, M);
+        public string Text3 => NativeStringReader.ReadStringLong(Address + 0x2E8+8, M);
     }
 }


### PR DESCRIPTION
I still use elem+0x320 offset for both(long, short) texts, which also became +8,
please check the new offset using your internal methods - it may not work in some cases :-)) 