### PR TITLE
3.15 Offsets and Subterranean Chart fix.

### DIFF
--- a/Core/PoEMemory/Elements/SubterraneanChart.cs
+++ b/Core/PoEMemory/Elements/SubterraneanChart.cs
@@ -4,6 +4,6 @@
     {
         private DelveElement _grid;
         public DelveElement GridElement =>
-            Address != 0 ? _grid ?? (_grid = GetObject<DelveElement>(M.Read<long>(Address + 0x1C0, 0x690))) : null;
+            Address != 0 ? _grid ?? (_grid = GetObject<DelveElement>(M.Read<long>(Address + 0x1C8, 0x698))) : null;
     }
 }

--- a/Core/PoEMemory/MemoryObjects/IngameUIElements.cs
+++ b/Core/PoEMemory/MemoryObjects/IngameUIElements.cs
@@ -51,7 +51,8 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public Element OpenRightPanel => GetObject<Element>(IngameUIElementsStruct.OpenRightPanel);
         public StashElement StashElement => GetObject<StashElement>(IngameUIElementsStruct.StashElement);
         public InventoryElement InventoryPanel => GetObject<InventoryElement>(IngameUIElementsStruct.InventoryPanel);
-        public Element TreePanel => GetObject<Element>(IngameUIElementsStruct.TreePanel);
+        public Element TreePanel => GetChildAtIndex(24);
+        public Element PVPTreePanel => GetChildAtIndex(25);
         public Element AtlasPanel => GetObject<Element>(IngameUIElementsStruct.AtlasPanel);
         public Element Atlas => AtlasPanel; // Required to fit with TehCheats Api, Random Feature uses this field.
         public Map Map => _map ??= GetObject<Map>(IngameUIElementsStruct.Map);

--- a/GameOffsets/IngameUElementsOffsets.cs
+++ b/GameOffsets/IngameUElementsOffsets.cs
@@ -43,7 +43,7 @@ namespace GameOffsets
         [FieldOffset(0x888)] public long RitualWindow;
         [FieldOffset(0x890)] public long RitualFavourPanel;
         [FieldOffset(0x898)] public long UltimatumProgressPanel;
-        [FieldOffset(0x910)] public long DelveDarkness;
+        [FieldOffset(0x8E0)] public long DelveDarkness;
         [FieldOffset(0x920)] public long AreaInstanceUi;
         [FieldOffset(0xA70)] public long GemLvlUpPanel;
         [FieldOffset(0xA78)] public long InvitesPanel;

--- a/GameOffsets/IngameUElementsOffsets.cs
+++ b/GameOffsets/IngameUElementsOffsets.cs
@@ -5,201 +5,224 @@ namespace GameOffsets
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct IngameUElementsOffsets
     {
-        [FieldOffset(0x210)] public long GetQuests;
-        [FieldOffset(0x238)] public long GameUI;
-        [FieldOffset(0x380)] public long Mouse;
-        [FieldOffset(0x388)] public long SkillBar;
-        [FieldOffset(0x390)] public long HiddenSkillBar; 
+        [FieldOffset(0x218)] public long GetQuests;
+        [FieldOffset(0x240)] public long GameUI;
+        [FieldOffset(0x390)] public long Mouse;
+        [FieldOffset(0x398)] public long SkillBar;
+        [FieldOffset(0x3A0)] public long HiddenSkillBar; 
         [FieldOffset(0x420)] public long ChatPanel; 
-        [FieldOffset(0x490)] public long QuestTracker;
-        [FieldOffset(0x518)] public long OpenLeftPanel;
-        [FieldOffset(0x520)] public long OpenRightPanel;
+        [FieldOffset(0x4A0)] public long QuestTracker;
+        [FieldOffset(0x508)] public long OpenLeftPanel;
+        [FieldOffset(0x510)] public long OpenRightPanel;
         [FieldOffset(0x540)] public long InventoryPanel;
-        [FieldOffset(0x508)] public long StashElement; // correct? it moved
-        [FieldOffset(0x570)] public long TreePanel;
-        [FieldOffset(0x578)] public long AtlasPanel;
-        [FieldOffset(0x5A8)] public long WorldMap;
+        [FieldOffset(0x548)] public long StashElement;
+        // [FieldOffset(0x570)] public long TreePanel; Removed from UI Struct, access through children index.
+        [FieldOffset(0x5F8)] public long AtlasPanel;
+        [FieldOffset(0x628)] public long WorldMap;
         [FieldOffset(0x648)] public long Map;
         [FieldOffset(0x650)] public long itemsOnGroundLabelRoot;
-        [FieldOffset(0x650)] public long BanditDialog;
+        [FieldOffset(0x658)] public long BanditDialog;
         [FieldOffset(0x6D8)] public long NpcDialog;
-        [FieldOffset(0x6E0)] public long QuestRewardWindow;
-        [FieldOffset(0x6f8)] public long PurchaseWindow; // 68 -> E8 (patch 16.7.21)
-        [FieldOffset(0x708)] public long SellWindow; // wrong (patch 16.7.21)
-        [FieldOffset(0x710)] public long TradeWindow; // 78 -> F0 (patch 16.7.21)
+        [FieldOffset(0x6F0)] public long QuestRewardWindow;
+        [FieldOffset(0x6F8)] public long PurchaseWindow;
+        [FieldOffset(0x700)] public long ExpeditionPurchaseWindow;
+        [FieldOffset(0x708)] public long SellWindow;
+        [FieldOffset(0x710)] public long ExpeditionSellWindow;
+        [FieldOffset(0x718)] public long TradeWindow;
 
-        [FieldOffset(0x6B0)] public long MapDeviceWindow;
-        [FieldOffset(0x708)] public long IncursionWindow;
-        [FieldOffset(0x728)] public long DelveWindow;
-        [FieldOffset(0x738)] public long ZanaMissionChoice;
-        [FieldOffset(0x748)] public long BetrayalWindow;
-        [FieldOffset(0x760)] public long CraftBenchWindow;
-        [FieldOffset(0x768)] public long UnveilWindow;
-        [FieldOffset(0x790)] public long SynthesisWindow;
-        [FieldOffset(0x7A0)] public long MetamorphWindow;
-        [FieldOffset(0x7B0)] public long HarvestWindow;
-        [FieldOffset(0x7E8)] public long RitualWindow;
-        [FieldOffset(0x7F0)] public long RitualFavourPanel;
-        [FieldOffset(0x7F8)] public long UltimatumProgressPanel;
-        [FieldOffset(0x848)] public long DelveDarkness;
-        [FieldOffset(0x858)] public long AreaInstanceUi;
-        [FieldOffset(0x950)] public long InvitesPanel;
-        [FieldOffset(0xA28)] public long GemLvlUpPanel;
-        [FieldOffset(0xA60)] public long ItemOnGroundTooltip;
+        [FieldOffset(0x750)] public long MapDeviceWindow;
+        [FieldOffset(0x7A8)] public long IncursionWindow;
+        [FieldOffset(0x7C8)] public long DelveWindow;
+        [FieldOffset(0x7D8)] public long ZanaMissionChoice;
+        [FieldOffset(0x7E8)] public long BetrayalWindow;
+        [FieldOffset(0x800)] public long CraftBenchWindow;
+        [FieldOffset(0x808)] public long UnveilWindow;
+        [FieldOffset(0x830)] public long SynthesisWindow;
+        [FieldOffset(0x840)] public long MetamorphWindow;
+        [FieldOffset(0x850)] public long HarvestWindow;
+        [FieldOffset(0x888)] public long RitualWindow;
+        [FieldOffset(0x890)] public long RitualFavourPanel;
+        [FieldOffset(0x898)] public long UltimatumProgressPanel;
+        [FieldOffset(0x910)] public long DelveDarkness;
+        [FieldOffset(0x920)] public long AreaInstanceUi;
+        [FieldOffset(0xA70)] public long GemLvlUpPanel;
+        [FieldOffset(0xA78)] public long InvitesPanel;
+        [FieldOffset(0xB50)] public long ItemOnGroundTooltip;
         [FieldOffset(0xAA0)] public long MapTabWindowStartPtr;
 
-        //[FieldOffset(0x210)] public long GetQuests;
-        //[FieldOffset(0x238)] public long GameUI;
-        //[FieldOffset(0x370)] public long Mouse;
-        //[FieldOffset(0x388)] public long SkillBar;
-        //[FieldOffset(0x390)] public long HiddenSkillBar;
-        //[FieldOffset(0x3B0)] public long PvpLeaveWithdrawPanel;
-        //[FieldOffset(0x3B8)] public long PvpTimerPanel;
-        //[FieldOffset(0x3C0)] public long PvpFightNotifyPanel;
-        //[FieldOffset(0x3C8)] public long PvpNextRoundNotifyNotifyPanel;
-        //[FieldOffset(0x3D0)] public long PvpStopSpectatingPanel;
+        //[FieldOffset(0x218)] public long GetQuests;
+        //[FieldOffset(0x240)] public long GameUI;
+        //[FieldOffset(0x258)] public long HealthPanel;
+        //[FieldOffset(0x260)] public long ManaPanel;
+        //[FieldOffset(0x280)] public long FlaskPanel;
+        //[FieldOffset(0x288)] public long ExperienceBarPanel;
+        //[FieldOffset(0x298)] public long MenuPanel;
+        //[FieldOffset(0x2A0)] public long MenuButton;
+        //[FieldOffset(0x2B8)] public long ClockPanel;
+        //[FieldOffset(0x338)] public long MTXShopButton;
+        //[FieldOffset(0x340)] public long HelpButton;
+        //[FieldOffset(0x358)] public long SkillPointAvailableButton;
+        //[FieldOffset(0x368)] public long SkipTutorialButton;
+        //[FieldOffset(0x380)] public long ToggleChatButton;
 
-        //[FieldOffset(0x3E0)] public long PvpMoreTimersPanel;
-        //[FieldOffset(0x3E8)] public long UI[25][6];
-        //[FieldOffset(0x3F0)] public long PvpSpectatingPanel;
-        //[FieldOffset(0x3F8)] public long UI[104];
+        //[FieldOffset(0x390)] public long Mouse;
+        //[FieldOffset(0x398)] public long SkillBar;
+        //[FieldOffset(0x3A0)] public long HiddenSkillBar;
+        //[FieldOffset(0x3B0)] public long Child19;
+        //[FieldOffset(0x3B8)] public long Child18;
+        //[FieldOffset(0x3D0)] public long PvpFightNotifyPanel;
+        //[FieldOffset(0x3E8)] public long Child51;
+        //[FieldOffset(0x400)] public long PvpSpectatingPanel;
 
-        //[FieldOffset(0x410)] public long ChatPanel;
+        //[FieldOffset(0x408)] public long Child109;
+        //[FieldOffset(0x410)] public long EditingNotifyPanel;
+        //[FieldOffset(0x420)] public long ChatPanel;
+        //[FieldOffset(0x428)] public long HideoutStashPanel;
+        //[FieldOffset(0x430)] public long Child116;
+        //[FieldOffset(0x438)] public long Child117;
+        //[FieldOffset(0x440)] public long BestiaryMissionCompletePanel;
+        //[FieldOffset(0x448)] public long BestiaryNewBeastNotifyPanel;
+        //[FieldOffset(0x450)] public long BestiaryNewRecipeNotifyPanel;
+        //[FieldOffset(0x488)] public long SulphiteProgressBar;
+        //[FieldOffset(0x490)] public long Child118;
+        //[FieldOffset(0x498)] public long Child119;
+        //[FieldOffset(0x4A0)] public long QuestTracker;
+        //[FieldOffset(0x4A8)] public long BenchCraftNewRecipeNotifyPanel;
+        //[FieldOffset(0x4C8)] public long HideoutUnlockNotifyPanel;
 
-        //[FieldOffset(0x420)] public long UI[111];
-        //[FieldOffset(0x428)] public long UI[112];
-        //[FieldOffset(0x430)] public long BestiaryMissionCompletePanel;
-        //[FieldOffset(0x438)] public long BestiaryNewBeastNotifyPanel;
-        //[FieldOffset(0x440)] public long BestiaryNewRecipeNotifyPanel;
+        //[FieldOffset(0x508)] public long OpenLeftPanel;
+        //[FieldOffset(0x510)] public long OpenRightPanel;
+        //[FieldOffset(0x518)] public long OpenLeftPanel2; // Holds same address as above.
+        //[FieldOffset(0x520)] public long OpenRightPanel2; // Holds same address as above.
 
-        //[FieldOffset(0x478)] public long SulphiteProgressBar;
-        //[FieldOffset(0x480)] public long UI[113];
-        //[FieldOffset(0x488)] public long UI[114];
-        //[FieldOffset(0x490)] public long QuestTracker;
-        //[FieldOffset(0x498)] public long BenchCraftNewRecipeNotifyPanel;
+        //[FieldOffset(0x530)] public long MtxStashPanel;
+        //[FieldOffset(0x538)] public long MtxShopPanel;
+        //[FieldOffset(0x540)] public long InventoryPanel;
+        //[FieldOffset(0x548)] public long StashElement;
 
-        //[FieldOffset(0x4B8)] public long HideoutUnlockNotifyPanel;
-
-        //[FieldOffset(0x598)] public long OpenLeftPanel;
-        //[FieldOffset(0x500)] public long OpenRightPanel;
-        //[FieldOffset(0x508)] public long OpenLeftPanel2; // Holds same address as above.
-        //[FieldOffset(0x510)] public long OpenRightPanel2; // Holds same address as above.
-        
-        //[FieldOffset(0x520)] public long MtxStashPanel;
-        //[FieldOffset(0x528)] public long MtxShopPanel;
-        //[FieldOffset(0x530)] public long InventoryPanel;
-        //[FieldOffset(0x538)] public long StashElement;
-
-        //[FieldOffset(0x548)] public long GuildStashPanel;
-        //[FieldOffset(0x550)] public long HideoutStashPanel; // Hideout stash panels from before rework.
-        //[FieldOffset(0x558)] public long SocialPanel;
-        //[FieldOffset(0x560)] public long TreePanel;
-        //[FieldOffset(0x568)] public long AtlasPanel;
-        //[FieldOffset(0x570)] public long CharacterPanel;
-        //[FieldOffset(0x578)] public long OptionsPanel;
-        //[FieldOffset(0x580)] public long ChallengesPanel;
-        //[FieldOffset(0x588)] public long PantheonPanel;
-        //[FieldOffset(0x590)] public long EventsPanel;
-        //[FieldOffset(0x598)] public long WorldMap;
-        //[FieldOffset(0x5A0)] public long MtxPanel;
-        //[FieldOffset(0x5A8)] public long DecorationsPanel;
-        //[FieldOffset(0x5B0)] public long HelpPanel;
-        //[FieldOffset(0x5B8)] public long Map;
-        //[FieldOffset(0x5C0)] public long itemsOnGroundLabelRoot;
-        //[FieldOffset(0x5C8)] public long VisibleHealthBars;
-        //[FieldOffset(0x5D0)] public long BanditDialog;
-
-        //[FieldOffset(0x5F8)] public long UI[123];
-
-        //[FieldOffset(0x640)] public long BuffPanel;
-        //[FieldOffset(0x648)] public long NpcDialog;
-        //[FieldOffset(0x660)] public long QuestRewardWindow;
-        //[FieldOffset(0x668)] public long PurchaseWindow;
-        //[FieldOffset(0x670)] public long SellWindow;
-        //[FieldOffset(0x678)] public long TradeWindow;
-        //[FieldOffset(0x680)] public long MapReceptacle;
-        //[FieldOffset(0x688)] public long PerandusCadiroOfferPanel;
-        //[FieldOffset(0x690)] public long LabyrinthDivineFontPanel;
-        //[FieldOffset(0x698)] public long TalismanStoneCirclePanel;
-        //[FieldOffset(0x6A0)] public long TrialPlaquePanel;
-        //[FieldOffset(0x6A8)] public long AscendancySelectPanel;
-        //[FieldOffset(0x6B0)] public long MapDeviceWindow;
-        //[FieldOffset(0x6B8)] public long DarkshrinePanel;
-        //[FieldOffset(0x6C0)] public long BestiaryCraftPanel;
-        //[FieldOffset(0x6C8)] public long LabyrinthSelectPanel;
-        //[FieldOffset(0x6D0)] public long LabyrinthMapPanel;
-        //[FieldOffset(0x6D8)] public long GuildTagEditor;
-        //[FieldOffset(0x6E0)] public long BroadcastMessagePanel;
-        //[FieldOffset(0x6E8)] public long FriendNoteEditorPanel;
-        //[FieldOffset(0x6F0)] public long BetaLadderScreen;
-
-        //[FieldOffset(0x700)] public long DivinationCardTradeScreen;
-        //[FieldOffset(0x708)] public long IncursionWindow;
-        //[FieldOffset(0x710)] public long IncursionCorruptionAltarPanel;
-        //[FieldOffset(0x718)] public long IncursionAltarOfSacrificePanel;
-        //[FieldOffset(0x720)] public long IncursionLapidaryLensPanel;
-        //[FieldOffset(0x728)] public long NikoSubterraneanChartPanel; // This is the subterrranean chart when talking to niko.
-        //[FieldOffset(0x730)] public long DelveWindow;  // This is the subterranean chart using in the mine.
-        //[FieldOffset(0x738)] public long ZanaMissionChoice;
-        
-        //[FieldOffset(0x748)] public long JunSyndicateInvestigationPanel; // this is the murder board when talking to Jun.
-        //[FieldOffset(0x750)] public long BetrayalWindow; // this is the murder board shown during Betrayal encounter.
-        //[FieldOffset(0x758)] public long HelenaHideoutSelectPanel;
-  //      [FieldOffset(0x760)] public long CraftBenchWindow;
-		//[FieldOffset(0x768)] public long UnveilWindow;
-        //[FieldOffset(0x770)] public long BetrayalTrappedStashPanel;
-        //[FieldOffset(0x778)] public long BetrayalTinysTrialPanel;
-        //[FieldOffset(0x780)] public long BetrayalSyndicateCraftingBenchPanel;
-        //[FieldOffset(0x788)] public long SynthesisSynthesiserPanel;
-        //[FieldOffset(0x790)] public long SynthesisWindow;
-        //[FieldOffset(0x798)] public long CassiaAnointPanel;
-        //[FieldOffset(0x7A0)] public long MetamorphWindow;  // This is the panel you encounter in maps.
-        //[FieldOffset(0x7A8)] public long TanesLabMetamorphWindow; // This is the panel you encounter in Tane's Lab.
-        //[FieldOffset(0x7B0)] public long HarvestWindow;
-        //[FieldOffset(0x7B8)] public long HorticraftingStationPanel;
-        //[FieldOffset(0x7C0)] public long HeistContractPanel;
-        //[FieldOffset(0x7C8)] public long HeistBlueprintPanel;
-        //[FieldOffset(0x7D0)] public long HeistAllyEquipmentPanel;
-        //[FieldOffset(0x7D8)] public long HeistGrandHeistPanel;
-        //[FieldOffset(0x7E0)] public long HeistLockerPanel;
-        //[FieldOffset(0x7E8)] public long RitualWindow;
-        //[FieldOffset(0x7F0)] public long RitualFavourPanel;
-        //[FieldOffset(0x7F8)] public long UltimatumProgressPanel;
-        //[FieldOffset(0x800)] public long UI[25][10];
-
-        //[FieldOffset(0x820)] public long UI[24]; Guild Perms
-
-        //[FieldOffset(0x838)] public long MapSettingsPanel;
-        //[FieldOffset(0x840)] public long UI[100];
-        //[FieldOffset(0x848)] public long DelveDarkness;
-        //[FieldOffset(0x850)] public long AreaInstanceUi;
-
-        //[FieldOffset(0x878)] public long MtxSalvagePanel;
-
-        //[FieldOffset(0x888)] public long ReportPlayerPanel;
-
-        //[FieldOffset(0x8A8)] public long DeadNotifyPanel;
-
-        //[FieldOffset(0x938)] public long HideoutMusicPanel;
-        //[FieldOffset(0x940)] public long UI[25][9];
-        //[FieldOffset(0x948)] public long ZoneTravelNotifyPanel;
-        //[FieldOffset(0x950)] public long InvitesPanel;
-
-        //[FieldOffset(0x9A0)] public long GemLvlUpPanel;
-
-        //[FieldOffset(0x9F8)] public long RampageKillCountPanel;
-        //[FieldOffset(0xA00)] public long IncursionKillCountPanel;
-        //[FieldOffset(0xA10)] public long ZeroMustSurvivePanel;
-        //[FieldOffset(0xA18)] public long SynthesisStabilizerProgressPanel;
-        //[FieldOffset(0xA20)] public long SynthesisRewardNotifyPanel;
-        //[FieldOffset(0xA28)] public long BlightProgressPanel;
-
-        //[FieldOffset(0xA40)] public long HeistNotifyPanel;
-        //[FieldOffset(0xA48)] public long UltimatumChallengeProgressPanel;
-        //[FieldOffset(0xA50)] public long UltimatumReturnToRingNotifyPanel;
-
-        //[FieldOffset(0xA60)] public long ItemOnGroundTooltip;
-        
+        //[FieldOffset(0x558)] public long GuildStashPanel;
+        //[FieldOffset(0x560)] public long HideoutStashPanel; // Hideout stash panels from before rework.
+        //[FieldOffset(0x568)] public long SocialPanel;
+        //[FieldOffset(0x000)] public long TreePanel; // No longer in UI struct, access via children (24 - regular, 25 - royale)
+        //[FieldOffset(0x5F8)] public long AtlasPanel;
+        //[FieldOffset(0x600)] public long CharacterPanel;
+        //[FieldOffset(0x608)] public long OptionsPanel;
+        //[FieldOffset(0x610)] public long ChallengesPanel;
+        //[FieldOffset(0x618)] public long PantheonPanel;
+        //[FieldOffset(0x620)] public long EventsPanel;
+        //[FieldOffset(0x628)] public long WorldMap;
+        //[FieldOffset(0x630)] public long MtxPanel;
+        //[FieldOffset(0x638)] public long DecorationsPanel;
+        //[FieldOffset(0x640)] public long HelpPanel;
+        //[FieldOffset(0x648)] public long Map;
+        //[FieldOffset(0x650)] public long itemsOnGroundLabelRoot;
+        //[FieldOffset(0x658)] public long BanditDialog;
+        //[FieldOffset(0x660)] public long Child8;
+        //[FieldOffset(0x668)] public long Child9;
+        //[FieldOffset(0x670)] public long Child10;
+        //[FieldOffset(0x680)] public long Child2;
+        //[FieldOffset(0x688)] public long Child128;
+        //[FieldOffset(0x6D0)] public long BuffPanel;
+        //[FieldOffset(0x6D8)] public long NpcDialog;
+        //[FieldOffset(0x6E8)] public long LeagueInterfaceButton;
+        //[FieldOffset(0x6F0)] public long QuestRewardWindow;
+        //[FieldOffset(0x6F8)] public long PurchaseWindow;
+        //[FieldOffset(0x700)] public long ExpeditionPurchaseWindow;
+        //[FieldOffset(0x708)] public long SellWindow;
+        //[FieldOffset(0x710)] public long ExpeditionSellWindow;
+        //[FieldOffset(0x718)] public long TradeWindow;
+        //[FieldOffset(0x720)] public long MapReceptacle;
+        //[FieldOffset(0x728)] public long PerandusCadiroOfferPanel;
+        //[FieldOffset(0x730)] public long LabyrinthDivineFontPanel;
+        //[FieldOffset(0x738)] public long TalismanStoneCirclePanel;
+        //[FieldOffset(0x740)] public long TrialPlaquePanel;
+        //[FieldOffset(0x748)] public long AscendancySelectPanel;
+        //[FieldOffset(0x750)] public long MapDeviceWindow;
+        //[FieldOffset(0x758)] public long DarkshrinePanel;
+        //[FieldOffset(0x760)] public long BestiaryCraftPanel;
+        //[FieldOffset(0x768)] public long LabyrinthSelectPanel;
+        //[FieldOffset(0x770)] public long LabyrinthMapPanel;
+        //[FieldOffset(0x778)] public long GuildTagEditor;
+        //[FieldOffset(0x780)] public long BroadcastMessagePanel;
+        //[FieldOffset(0x788)] public long FriendNoteEditorPanel;
+        //[FieldOffset(0x790)] public long BetaLadderScreen;
+        //[FieldOffset(0x798)] public long PVPScoreboardPanel;
+        //[FieldOffset(0x7A0)] public long DivinationCardTradeScreen;
+        //[FieldOffset(0x7A8)] public long IncursionWindow;
+        //[FieldOffset(0x7B0)] public long IncursionCorruptionAltarPanel;
+        //[FieldOffset(0x7B8)] public long IncursionAltarOfSacrificePanel;
+        //[FieldOffset(0x7C0)] public long IncursionLapidaryLensPanel;
+        //[FieldOffset(0x7C8)] public long NikoSubterraneanChartPanel;
+        //[FieldOffset(0x7D0)] public long DelveWindow; // Not used.
+        //[FieldOffset(0x7D8)] public long ZanaMissionChoice;
+        //[FieldOffset(0x7E0)] public long SupportGemsTutorialPanel;
+        //[FieldOffset(0x7E8)] public long JunSyndicateInvestigationPanel;
+        //[FieldOffset(0x7F0)] public long BetrayalWindow; // Not used.
+        //[FieldOffset(0x7F8)] public long HelenaHideoutSelectPanel;
+        //[FieldOffset(0x800)] public long CraftBenchWindow;
+        //[FieldOffset(0x808)] public long UnveilWindow;
+        //[FieldOffset(0x810)] public long BetrayalTrappedStashPanel;
+        //[FieldOffset(0x818)] public long BetrayalTinysTrialPanel;
+        //[FieldOffset(0x820)] public long BetrayalSyndicateCraftingBenchPanel;
+        //[FieldOffset(0x828)] public long SynthesisSynthesiserPanel;
+        //[FieldOffset(0x830)] public long SynthesisWindow;
+        //[FieldOffset(0x838)] public long CassiaAnointPanel;
+        //[FieldOffset(0x840)] public long MetamorphWindow;  // This is the panel you encounter in maps.
+        //[FieldOffset(0x848)] public long TanesLabMetamorphWindow; // This is the panel you encounter in Tane's Lab.
+        //[FieldOffset(0x850)] public long HarvestWindow;
+        //[FieldOffset(0x858)] public long HorticraftingStationPanel;
+        //[FieldOffset(0x860)] public long HeistContractPanel;
+        //[FieldOffset(0x868)] public long HeistBlueprintPanel;
+        //[FieldOffset(0x870)] public long HeistAllyEquipmentPanel;
+        //[FieldOffset(0x878)] public long HeistGrandHeistPanel;
+        //[FieldOffset(0x880)] public long HeistLockerPanel;
+        //[FieldOffset(0x888)] public long RitualWindow;
+        //[FieldOffset(0x890)] public long RitualFavourPanel;
+        //[FieldOffset(0x898)] public long UltimatumProgressPanel;
+        //[FieldOffset(0x8A0)] public long ExpeditionMapPanel;
+        //[FieldOffset(0x8A8)] public long ExpeditionLogbookPanel;
+        //[FieldOffset(0x8B0)] public long ExpeditionLockerPanel;
+        //[FieldOffset(0x8B8)] public long ItemBoxPanel;
+        //[FieldOffset(0x8E0)] public long Child21;
+        //[FieldOffset(0x900)] public long MapSettingsPanel;
+        //[FieldOffset(0x908)] public long Child106;
+        //[FieldOffset(0x910)] public long Child139;
+        //[FieldOffset(0x920)] public long AreaInstanceUi;
+        //[FieldOffset(0x928)] public long Child130;
+        //[FieldOffset(0x930)] public long Child131;
+        //[FieldOffset(0x938)] public long MysteryBoxPanel;
+        //[FieldOffset(0x940)] public long MtxSalvagePanel;
+        //[FieldOffset(0x948)] public long MTXReclaimPanel;
+        //[FieldOffset(0x950)] public long MtxCombinePanel;
+        //[FieldOffset(0x958)] public long ReportPlayerPanel;
+        //[FieldOffset(0x960)] public long Child136;
+        //[FieldOffset(0x970)] public long DeadNotifyPanel;
+        //[FieldOffset(0x998)] public long SkipAheadButton;
+        //[FieldOffset(0x9F8)] public long Child1;
+        //[FieldOffset(0xA08)] public long HideoutMusicPanel;
+        //[FieldOffset(0xA18)] public long ZoneTravelNotifyPanel;
+        //[FieldOffset(0xA20)] public long Child126;
+        //[FieldOffset(0xA28)] public long Child5;
+        //[FieldOffset(0xA70)] public long GemLvlUpPanel;
+        //[FieldOffset(0xA78)] public long Child114;
+        //[FieldOffset(0xA88)] public long SkillBarMessagePanel;
+        //[FieldOffset(0xAC8)] public long Child0;
+        //[FieldOffset(0xAD0)] public long RampageKillCountPanel;
+        //[FieldOffset(0xAD8)] public long IncursionKillCountPanel;
+        //[FieldOffset(0xAE0)] public long ZeroMustSurvivePanel;
+        //[FieldOffset(0xAE8)] public long SyndicateNotifyPanel;
+        //[FieldOffset(0xAF0)] public long SynthesisStabilizerProgressPanel;
+        //[FieldOffset(0xAF8)] public long SynthesisRewardNotifyPanel;
+        //[FieldOffset(0xB00)] public long RootNotifyPanel;
+        //[FieldOffset(0xB08)] public long RoyaleWaitingForOthersPanel;
+        //[FieldOffset(0xB10)] public long RoyaleNotifyPanel;
+        //[FieldOffset(0xB18)] public long BlightProgressPanel;
+        //[FieldOffset(0xB28)] public long Child14;
+        //[FieldOffset(0xB30)] public long HeistNotifyPanel;
+        //[FieldOffset(0xB38)] public long UltimatumReturnToRingNotifyPanel;
+        //[FieldOffset(0xB48)] public long MissionRewardNotifyPanel;
+        //[FieldOffset(0xB50)] public long ItemOnGroundTooltip;
+        //[FieldOffset(0xB58)] public long Child138;
         //[FieldOffset(0xAA0)] public long MapTabWindowStartPtr;
     }
 }

--- a/GameOffsets/ServerDataOffsets.cs
+++ b/GameOffsets/ServerDataOffsets.cs
@@ -24,15 +24,15 @@ namespace GameOffsets
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct ServerPlayerDataOffsets
     {
-        [FieldOffset(0x160)] public NativePtrArray PassiveSkillIds;
+        [FieldOffset(0x170)] public NativePtrArray PassiveSkillIds;
         //[FieldOffset(0x178)] public NativePtrArray PassiveJewelSocketIds;
-        [FieldOffset(0x200)] public byte PlayerClass;
-        [FieldOffset(0x204)] public int CharacterLevel;
-        [FieldOffset(0x208)] public int PassiveRefundPointsLeft;
-        [FieldOffset(0x20C)] public int QuestPassiveSkillPoints;
-        [FieldOffset(0x210)] public int FreePassiveSkillPointsLeft;
-        [FieldOffset(0x214)] public int TotalAscendencyPoints;
-        [FieldOffset(0x218)] public int SpentAscendencyPoints;
+        [FieldOffset(0x210)] public byte PlayerClass;
+        [FieldOffset(0x214)] public int CharacterLevel;
+        [FieldOffset(0x218)] public int PassiveRefundPointsLeft;
+        [FieldOffset(0x21C)] public int QuestPassiveSkillPoints;
+        [FieldOffset(0x220)] public int FreePassiveSkillPointsLeft;
+        [FieldOffset(0x224)] public int TotalAscendencyPoints;
+        [FieldOffset(0x228)] public int SpentAscendencyPoints;
     }
 
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
@@ -40,61 +40,61 @@ namespace GameOffsets
     {
         public const int Skip = 0x7000;
 
-        [FieldOffset(0x8219 - Skip)] public long PlayerRelatedData;
-        [FieldOffset(0x82b8 - Skip)] public byte NetworkState;
-        [FieldOffset(0x82d0 - Skip)] public NativeStringU League;
-        [FieldOffset(0x8360 - Skip)] public float TimeInGame;
+        [FieldOffset(0x8218 - Skip)] public long PlayerRelatedData;
+        [FieldOffset(0x82B8 - Skip)] public byte NetworkState;
+        [FieldOffset(0x82D0 - Skip)] public NativeStringU League;
+        [FieldOffset(0x8350 - Skip)] public float TimeInGame;
         [FieldOffset(0x8368 - Skip)] public int Latency;
         [FieldOffset(0x8370 - Skip)] public NativePtrArray PlayerStashTabs;
-        [FieldOffset(0x8378 - Skip)] public NativePtrArray GuildStashTabs;
-        [FieldOffset(0x83F0 - Skip)] public long FriendsList;
-        //[FieldOffset(0x7F80 - Skip)] public long FriendNoteList;
-        //[FieldOffset(0x7F90 - Skip)] public NativePtrArray FriendsArray;
-        [FieldOffset(0x8458 - Skip)] public NativePtrArray PendingInvites;
+        [FieldOffset(0x8388 - Skip)] public NativePtrArray GuildStashTabs;
+        [FieldOffset(0x8418 - Skip)] public long FriendsList;
+        //[FieldOffset(0x8430 - Skip)] public long FriendNoteList;
+        //[FieldOffset(0x8440 - Skip)] public NativePtrArray FriendsArray;
+        [FieldOffset(0x8480 - Skip)] public NativePtrArray PendingInvites;
         [FieldOffset(0x8500 - Skip)] public byte PartyStatusType;
-        [FieldOffset(0x8058 - Skip)] public NativePtrArray CurrentParty;
-        [FieldOffset(0x8070 - Skip)] public byte PartyAllocationType;
-        [FieldOffset(0x8071 - Skip)] public bool PartyDownscaleDisabled;
-        [FieldOffset(0x8088 - Skip)] public long GuildList;
+        [FieldOffset(0x8508 - Skip)] public NativePtrArray CurrentParty;
+        [FieldOffset(0x8520 - Skip)] public byte PartyAllocationType;
+        [FieldOffset(0x8521 - Skip)] public bool PartyDownscaleDisabled;
+        [FieldOffset(0x8538 - Skip)] public long GuildList;
         //[FieldOffset(0x8098 - Skip)] public NativePtrArray GuildArray;
-        [FieldOffset(0x80D8 - Skip)] public long GuildNameAddress;
+        [FieldOffset(0x8588 - Skip)] public long GuildNameAddress;
         [FieldOffset(0x8590 - Skip)] public SkillBarIdsStruct SkillBarIds;
-        [FieldOffset(0x8138 - Skip)] public NativePtrArray NearestPlayers;
+        [FieldOffset(0x85E8 - Skip)] public NativePtrArray NearestPlayers;
         //[FieldOffset(0x8168 - Skip)] public NativePtrArray MinimapIcons;
         //[FieldOffset(0x8188 - Skip)] public NativePtrArray LocalPlayer;
         [FieldOffset(0x8758 - Skip)] public NativePtrArray PlayerInventories;
-        [FieldOffset(0x83D8 - Skip)] public NativePtrArray NPCInventories;
-        [FieldOffset(0x8510 - Skip)] public NativePtrArray GuildInventories;
+        [FieldOffset(0x8898 - Skip)] public NativePtrArray NPCInventories;
+        [FieldOffset(0x89D8 - Skip)] public NativePtrArray GuildInventories;
 
-        [FieldOffset(0x8678 - Skip)] public ushort TradeChatChannel;
-        [FieldOffset(0x8680 - Skip)] public ushort GlobalChatChannel;
-        [FieldOffset(0x86D0 - Skip)] public ushort LastActionId;
+        [FieldOffset(0x8B40 - Skip)] public ushort TradeChatChannel;
+        [FieldOffset(0x8B48 - Skip)] public ushort GlobalChatChannel;
+        [FieldOffset(0x8BE8 - Skip)] public ushort LastActionId;
 
         //[FieldOffset(0x8708 - Skip)] public long InstanceLeagueInfo;
 
         // Note: Search for a LONG value equal to your current amount of completed maps.
         //       Previous byte is a linked list of maps. Map list will be the next byte.
-        [FieldOffset(0x8728 - Skip)] public long MavenMapsList;
-        [FieldOffset(0x8730 - Skip)] public long MavenMapsCount;
-        [FieldOffset(0x8738 - Skip)] public long MavenMapsArray;
-        [FieldOffset(0x8768 - Skip)] public long CompletedMapsList;
-        [FieldOffset(0x8770 - Skip)] public long CompletedMapsCount;
-        [FieldOffset(0x8778 - Skip)] public long CompletedMapsArray;
-        [FieldOffset(0x87A8 - Skip)] public long BonusCompletedAreasList;
-        [FieldOffset(0x87B0 - Skip)] public long BonusCompletedAreasCount;
-        [FieldOffset(0x87B8 - Skip)] public long BonusCompletedAreasArray;
-        [FieldOffset(0x87E8 - Skip)] public long AwakenedAreasList;
-        [FieldOffset(0x87F0 - Skip)] public long AwakenedAreasCount;
-        [FieldOffset(0x87F8 - Skip)] public long AwakenedAreasArray;
+        [FieldOffset(0x8C40 - Skip)] public long MavenMapsList;
+        [FieldOffset(0x8C48 - Skip)] public long MavenMapsCount;
+        [FieldOffset(0x8C50 - Skip)] public long MavenMapsArray;
+        [FieldOffset(0x8C80 - Skip)] public long CompletedMapsList;
+        [FieldOffset(0x8C88 - Skip)] public long CompletedMapsCount;
+        [FieldOffset(0x8C90 - Skip)] public long CompletedMapsArray;
+        [FieldOffset(0x8CC0 - Skip)] public long BonusCompletedAreasList;
+        [FieldOffset(0x8CC8 - Skip)] public long BonusCompletedAreasCount;
+        [FieldOffset(0x8CD0 - Skip)] public long BonusCompletedAreasArray;
+        [FieldOffset(0x8D00 - Skip)] public long AwakenedAreasList;
+        [FieldOffset(0x8D08 - Skip)] public long AwakenedAreasCount;
+        [FieldOffset(0x8D10 - Skip)] public long AwakenedAreasArray;
         //[FieldOffset(0x8A08 - Skip)] public long BestiaryCapturedMonsterList;
 
-        public const int AtlasRegionUpgrades = 0x8872;
-        public const int AtlasWatchtowerLocations = 0x8880;
+        public const int AtlasRegionUpgrades = 0x8D8A;
+        public const int AtlasWatchtowerLocations = 0x8D98;
         public const int BestiaryBeastsCapturedCounts = 0x8A68;
 
-        [FieldOffset(0x9228 - Skip)] public int DialogDepth;
-        [FieldOffset(0x92AC - Skip)] public byte MonsterLevel;
-        [FieldOffset(0x92AD - Skip)] public byte MonstersRemaining;
+        [FieldOffset(0x9770 - Skip)] public int DialogDepth;
+        [FieldOffset(0x9774 - Skip)] public byte MonsterLevel;
+        [FieldOffset(0x9775 - Skip)] public byte MonstersRemaining;
         //[FieldOffset(0x9328 - Skip)] public long LeftIncursionArchitectKey;
         //[FieldOffset(0x9338 - Skip)] public long RightIncursionArchitectKey;
         [FieldOffset(0x9820 - Skip)] public int CurrentAzuriteAmount;


### PR DESCRIPTION
MapTabWindowStartPtr is still missing. The text sources seemed to have been moved in the cells for the subterranean chart. Not sure what they were before but it doesn't look like anyone was using them.