### PR TITLE
Avoid calling into library code on zero-size ReadAsArray calls

### DIFF
--- a/Core/Memory.cs
+++ b/Core/Memory.cs
@@ -126,6 +126,8 @@ namespace ExileCore
 
         public T[] ReadAsArray<T>(long addr, int size) where T : struct
         {
+            if (size == 0)
+                return Array.Empty<T>();
             T[] buffer = new T[size];
             try
             {


### PR DESCRIPTION
The call potentially involves pinning the array reference, it's much cheaper to just return the empty array in this case