### PR TITLE
Improve the GetChildFromIndices error messages

### DIFF
--- a/Core/PoEMemory/Element.cs
+++ b/Core/PoEMemory/Element.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using ExileCore.PoEMemory.Elements;
 using ExileCore.Shared.Cache;
 using ExileCore.Shared.Helpers;
 using GameOffsets;
-using MoreLinq;
 using SharpDX;
 
 namespace ExileCore.PoEMemory
@@ -171,23 +171,40 @@ namespace ExileCore.PoEMemory
         {
             var currentElement = this;
 
-            foreach (var index in indices)
+            StringBuilder BuildErrorString(int errorIndex)
             {
+                var str = new StringBuilder();
+                foreach (var i in indices)
+                {
+                    if (i == errorIndex)
+                    {
+                        str.Append('>');
+                    }
+
+                    str.AppendFormat("[{0}] ", i);
+                    if (i == errorIndex)
+                    {
+                        str.Append('<');
+                    }
+                }
+
+                return str;
+            }
+
+            for (var indexNumber = 0; indexNumber < indices.Length; indexNumber++)
+            {
+                var index = indices[indexNumber];
                 currentElement = currentElement.GetChildAtIndex(index);
 
                 if (currentElement == null)
                 {
-                    var str = "";
-                    indices.ForEach(i => str += $"[{i}] ");
-                    DebugWindow.LogMsg($"{nameof(Element)} with index: {index} not found. Indices: {str}");
+                    DebugWindow.LogMsg($"{nameof(Element)} with index {index} was not found. Indices: {BuildErrorString(indexNumber)}");
                     return null;
                 }
 
                 if (currentElement.Address == 0)
                 {
-                    var str = "";
-                    indices.ForEach(i => str += $"[{i}] ");
-                    DebugWindow.LogMsg($"{nameof(Element)} with index: {index} 0 address. Indices: {str}");
+                    DebugWindow.LogMsg($"{nameof(Element)} with index {index} has address = 0. Indices: {BuildErrorString(indexNumber)}");
                     return GetObject<Element>(0);
                 }
             }


### PR DESCRIPTION
It won't hurt to actually point out which indexing operation failed