### PR TITLE
Allow plugins to use the packed texture helper

### DIFF
--- a/Core/BaseSettingsPlugin.cs
+++ b/Core/BaseSettingsPlugin.cs
@@ -209,6 +209,24 @@ namespace ExileCore
             return texture;
         }
 
+        public AtlasTexturesProcessor CreateAtlas(string configPath, string texturePath)
+        {
+            if (!File.Exists(configPath))
+            {
+                LogError($"Plugin '{Name}': Can't find atlas json config file in '{configPath}'", 20);
+                return new AtlasTexturesProcessor("%AtlasNotFound%");
+            }
+
+            if (!File.Exists(texturePath))
+            {
+                LogError($"Plugin '{Name}': Can't find atlas png texture file in '{texturePath}' ", 20);
+                return new AtlasTexturesProcessor("%AtlasNotFound%");
+            }
+
+            Graphics.InitImage(texturePath, false);
+            return new AtlasTexturesProcessor(configPath, texturePath);
+        }
+
         #endregion
     }
 }

--- a/Core/Shared/AtlasHelper/AtlasTexturesProcessor.cs
+++ b/Core/Shared/AtlasHelper/AtlasTexturesProcessor.cs
@@ -6,7 +6,7 @@ using SharpDX;
 
 namespace ExileCore.Shared.AtlasHelper
 {
-    internal sealed class AtlasTexturesProcessor
+    public sealed class AtlasTexturesProcessor
     {
         private readonly Dictionary<string, AtlasTexture> _atlasTextures = new Dictionary<string, AtlasTexture>();
         private static readonly AtlasTexture MISSING_TEXTURE;


### PR DESCRIPTION
It was already available indirectly through the GetAtlasTexture method, but this allows for more fine-grained control and multiple atlases per plugin (which is useful if some of the atlases are external to the plugin)