### PR TITLE
Update Sockets.cs

### DIFF
--- a/Core/PoEMemory/Components/Sockets.cs
+++ b/Core/PoEMemory/Components/Sockets.cs
@@ -146,7 +146,7 @@ namespace ExileCore.PoEMemory.Components
             }
         }
 
-        public class SocketedGem
+        public struct SocketedGem
         {
             public Entity GemEntity;
             public int SocketIndex;


### PR DESCRIPTION
Fixed lifetime issue related to List<SocketedGem> collecting SocketedGem by ref instead of by value.

Users can now access the socket gems of an item.