### PR TITLE
Mods Component Offsets update

### DIFF
--- a/Core/PoEMemory/Components/Mods.cs
+++ b/Core/PoEMemory/Components/Mods.cs
@@ -122,14 +122,14 @@ namespace ExileCore.PoEMemory.Components
                 return mods;
             }
 
-            if (source.Size / GameOffsets.Components.Mods.ItemModRecordSize > 24)
+            if (source.Size / ModsComponentOffsets.ItemModRecordSize > 24)
             {
                 return mods;
             }
 
             for (var modAddress = source.First;
                  modAddress < source.Last;
-                 modAddress += GameOffsets.Components.Mods.ItemModRecordSize)
+                 modAddress += ModsComponentOffsets.ItemModRecordSize)
             {
                 mods.Add(GetObject<ItemMod>(modAddress));
             }
@@ -146,7 +146,7 @@ namespace ExileCore.PoEMemory.Components
             }
 
             var readPointersArray =
-                M.ReadPointersArray(source.First, source.Last, GameOffsets.Components.Mods.StatRecordSize);
+                M.ReadPointersArray(source.First, source.Last, ModsComponentOffsets.StatRecordSize);
 
             stats.AddRange(readPointersArray.Select(statAddress =>
                 Cache.StringCache.Read($"{nameof(Mods)}{statAddress}", () => M.ReadStringU(statAddress))));
@@ -162,9 +162,9 @@ namespace ExileCore.PoEMemory.Components
                 return string.Empty;
             }
 
-            for (var first = source.First; first < source.Last; first += GameOffsets.Components.Mods.NameRecordSize)
+            for (var first = source.First; first < source.Last; first += ModsComponentOffsets.NameRecordSize)
             {
-                words.Add(M.ReadStringU(M.Read<long>(first, GameOffsets.Components.Mods.NameOffset)).Trim());
+                words.Add(M.ReadStringU(M.Read<long>(first, ModsComponentOffsets.NameOffset)).Trim());
             }
 
             return Cache.StringCache.Read($"{nameof(Mods)}{source.First}", () => string.Join(" ", words.ToArray()));

--- a/Core/PoEMemory/Components/Mods.cs
+++ b/Core/PoEMemory/Components/Mods.cs
@@ -1,103 +1,135 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using ExileCore.PoEMemory.MemoryObjects;
-using ExileCore.PoEMemory.Models;
-using ExileCore.Shared.Cache;
-using ExileCore.Shared.Enums;
-using ExileCore.Shared.Helpers;
-using GameOffsets;
-using GameOffsets.Native;
-
 namespace ExileCore.PoEMemory.Components
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using ExileCore.PoEMemory.MemoryObjects;
+    using ExileCore.PoEMemory.Models;
+    using ExileCore.Shared.Cache;
+    using ExileCore.Shared.Enums;
+    using ExileCore.Shared.Helpers;
+    using GameOffsets;
+    using GameOffsets.Native;
+
     public class Mods : Component
     {
-        private readonly CachedValue<ModsComponentOffsets> _CachedValue;
+        private readonly CachedValue<ModsComponentOffsets> _cachedData;
+        private readonly CachedValue<ModsComponentDetailsOffsets> _cachedDetails;
 
         public Mods()
         {
-            _CachedValue = new FrameCache<ModsComponentOffsets>(() => M.Read<ModsComponentOffsets>(Address));
+            _cachedData =
+                new FrameCache<ModsComponentOffsets>(() => M.Read<ModsComponentOffsets>(Address));
+            _cachedDetails =
+                new FrameCache<ModsComponentDetailsOffsets>(() => M.Read<ModsComponentDetailsOffsets>(_cachedData.Value.ModsComponentDetailsKey));
         }
 
-        public ModsComponentOffsets ModsStruct => _CachedValue.Value;
+        private ModsComponentOffsets _data => _cachedData.Value;
 
-        public string UniqueName => GetUniqueName(ModsStruct.UniqueName);
-        public bool Identified => Address != 0 && ModsStruct.Identified;
-        public ItemRarity ItemRarity => Address != 0 ? (ItemRarity) ModsStruct.ItemRarity : ItemRarity.Normal;
+        private ModsComponentDetailsOffsets _details => _cachedDetails.Value;
 
-        public long Hash => ModsStruct.ImplicitModsArray.GetHashCode() ^ ModsStruct.ExplicitModsArray.GetHashCode() ^
-                            ModsStruct.GetHashCode();
+        private Lazy<List<ItemMod>> _enchantedMods =>
+            new Lazy<List<ItemMod>>(() => GetMods(_data.EnchantedModsArray).ToList());
 
-        public int ItemLevel => Address != 0 ? ModsStruct.ItemLevel : 1;
-        public int RequiredLevel => Address != 0 ? ModsStruct.RequiredLevel : 1;
-        public bool IsUsable => Address != 0 && ModsStruct.IsUsable == 1;
-        public bool IsMirrored => Address != 0 && ModsStruct.IsMirrored == 1;
-        public bool IsSplit => Address != 0 && ModsStruct.IsSplit == 1;
-        public string IncubatorName => Address != 0 && ModsStruct.IncubatorKey != 0
-            ? M.ReadStringU(M.Read<long>(ModsStruct.IncubatorKey, 0x20)) : null;
-        public short IncubatorKills => ModsStruct.IncubatorKillCount;
+        private Lazy<List<ItemMod>> _explicitMods =>
+            new Lazy<List<ItemMod>>(() => GetMods(_data.ExplicitModsArray).ToList());
 
-        private Lazy<List<ItemMod>> _ScourgedMods =>
-            new Lazy<List<ItemMod>>(() => GetMods(ModsStruct.ScourgeModsArray).ToList());
+        private Lazy<List<ItemMod>> _implicitMods =>
+            new Lazy<List<ItemMod>>(() => GetMods(_data.ImplicitModsArray).ToList());
 
-        public IList<ItemMod> ScourgedMods => _ScourgedMods.Value;
+        private Lazy<List<ItemMod>> _scourgedMods =>
+            new Lazy<List<ItemMod>>(() => GetMods(_data.ScourgeModsArray).ToList());
 
-        private Lazy<List<ItemMod>> _EnchantedMods =>
-            new Lazy<List<ItemMod>>(() => GetMods(ModsStruct.EnchantedModsArray).ToList());
+        [Obsolete("Use FracturedCount", false)]
+        public int CountFractured => FracturedCount;
 
-        public IList<ItemMod> EnchantedMods => _EnchantedMods.Value;
+        public IEnumerable<ItemMod> EnchantedMods => _enchantedMods.Value;
 
-        private Lazy<List<ItemMod>> _ImplicitMods =>
-            new Lazy<List<ItemMod>>(() => GetMods(ModsStruct.ImplicitModsArray).ToList());
+        public IEnumerable<ItemMod> ExplicitMods => _explicitMods.Value;
 
-        public IList<ItemMod> ImplicitMods => _ImplicitMods.Value;
+        public int FracturedCount => HumanFracturedStats.Count;
 
-        private Lazy<List<ItemMod>> _ExplicitMods =>
-            new Lazy<List<ItemMod>>(() => GetMods(ModsStruct.ExplicitModsArray).ToList());
-        public IList<ItemMod> ExplicitMods => _ExplicitMods.Value;
+        public long Hash => _data.ImplicitModsArray.GetHashCode()
+          ^ _data.ExplicitModsArray.GetHashCode()
+          ^ _data.GetHashCode();
+
+        [Obsolete("Use IsFractured", false)]
+        public bool HaveFractured => IsFractured;
+
+        public List<string> HumanCraftedStats => GetStats(_details.CraftedStatsArray);
+
+        public List<string> HumanEnchantedStats => GetStats(_details.EnchantedStatsArray);
+
+        public List<string> HumanFracturedStats => GetStats(_details.FracturedStatsArray);
+
+        public List<string> HumanImpStats => GetStats(_details.ImplicitStatsArray);
+
+        public List<string> HumanScourgeStats => GetStats(_details.ScourgeStatsArray);
+
+        public List<string> HumanStats => GetStats(_details.ExplicitStatsArray);
+
+        public bool Identified => Address != 0 && _data.Identified;
+
+        public IEnumerable<ItemMod> ImplicitMods => _implicitMods.Value;
+
+        public short IncubatorKills => _data.IncubatorKillCount;
+
+        public string IncubatorName =>
+            Address != 0 && _data.IncubatorKey != 0 ? M.ReadStringU(M.Read<long>(_data.IncubatorKey, 0x20)) : null;
+
+        public bool IsFractured => FracturedCount > 0;
+
+        public bool IsMirrored => Address != 0 && _data.IsMirrored == 1;
+
+        public bool IsSplit => Address != 0 && _data.IsSplit == 1;
+
+        public bool IsSynthesized => ItemMods != null && ItemMods.Any(x => x.RawName.StartsWith("SynthesisImplicit"));
+
+        public bool IsTalisman => ItemMods != null && ItemMods.Any(x => x.RawName.StartsWith("Talisman"));
+
+        public bool IsUsable => Address != 0 && _data.IsUsable == 1;
+
+        public bool IsVeiled => VeiledCount > 0;
+
+        public int ItemLevel => Address != 0 ? _data.ItemLevel : 1;
 
         public List<ItemMod> ItemMods => ScourgedMods.Concat(EnchantedMods, ImplicitMods, ExplicitMods).ToList();
+
+        public ItemRarity ItemRarity => Address != 0 ? (ItemRarity)_data.ItemRarity : ItemRarity.Normal;
+
         public ItemStats ItemStats => new ItemStats(Owner);
-        public List<string> HumanImpStats => GetStats(ModsStruct.ImplicitStatsArray);
-        public List<string> HumanEnchantedStats => GetStats(ModsStruct.EnchantedStatsArray);
-        public List<string> HumanScourgeStats => GetStats(ModsStruct.ScourgeStatsArray);
-        public List<string> HumanStats => GetStats(ModsStruct.ExplicitStatsArray);
-        public List<string> HumanCraftedStats => GetStats(ModsStruct.CraftedStatsArray);
-        public List<string> HumanFracturedStats => GetStats(ModsStruct.FracturedStatsArray);
-        public int FracturedCount => HumanFracturedStats.Count;
-        public bool IsFractured => FracturedCount > 0;
-        public bool IsSynthesized => ItemMods != null && 
-                                     ItemMods.Any(x => x.RawName.StartsWith("SynthesisImplicit"));
+
+        public int RequiredLevel => Address != 0 ? _data.RequiredLevel : 1;
+
+        public IEnumerable<ItemMod> ScourgedMods => _scourgedMods.Value;
+
+        [Obsolete("Use IsSynthesized", false)]
+        public bool Synthesised => IsSynthesized;
+
         public int SynthesizedCount => IsSynthesized ? HumanImpStats.Count : 0;
-        public bool IsTalisman => ItemMods != null &&
-                                  ItemMods.Any(x => x.RawName.StartsWith("Talisman"));
+
         public int TalismanCount => IsTalisman ? HumanImpStats.Count : 0;
+
+        public string UniqueName => GetUniqueName(_data.UniqueName);
+
         public int VeiledCount => ItemMods?.Count(x => x.Group.StartsWith("Veiled")) ?? 0;
-        public bool IsVeiled => VeiledCount > 0;
-        
-        private string GetUniqueName(NativePtrArray source)
-        {
-            var words = new List<string>();
-            if (Address == 0) return string.Empty;
-
-            for (var first = source.First; first < source.Last; first += ModsComponentOffsets.NameRecordSize)
-            {
-                words.Add(M.ReadStringU(M.Read<long>(first, ModsComponentOffsets.NameOffset)).Trim());
-            }
-
-            return Cache.StringCache.Read($"{nameof(Mods)}{source.First}", () => string.Join(" ", words.ToArray()));
-        }
 
         private IEnumerable<ItemMod> GetMods(NativePtrArray source)
         {
             var mods = new List<ItemMod>();
-            if (Address == 0) return mods;
-            if (source.Size / ModsComponentOffsets.ItemModRecordSize > 24) return mods;
+            if (Address == 0)
+            {
+                return mods;
+            }
+
+            if (source.Size / GameOffsets.Components.Mods.ItemModRecordSize > 24)
+            {
+                return mods;
+            }
 
             for (var modAddress = source.First;
-                modAddress < source.Last;
-                modAddress += ModsComponentOffsets.ItemModRecordSize)
+                 modAddress < source.Last;
+                 modAddress += GameOffsets.Components.Mods.ItemModRecordSize)
             {
                 mods.Add(GetObject<ItemMod>(modAddress));
             }
@@ -108,23 +140,34 @@ namespace ExileCore.PoEMemory.Components
         private List<string> GetStats(NativePtrArray source)
         {
             var stats = new List<string>();
-            if (Address == 0) return stats;
-            var readPointersArray = M.ReadPointersArray(source.First, source.Last, ModsComponentOffsets.StatRecordSize);
-
-            foreach (var statAddress in readPointersArray)
+            if (Address == 0)
             {
-                stats.Add(Cache.StringCache.Read($"{nameof(Mods)}{statAddress}", () => M.ReadStringU(statAddress)));
+                return stats;
             }
+
+            var readPointersArray =
+                M.ReadPointersArray(source.First, source.Last, GameOffsets.Components.Mods.StatRecordSize);
+
+            stats.AddRange(readPointersArray.Select(statAddress =>
+                Cache.StringCache.Read($"{nameof(Mods)}{statAddress}", () => M.ReadStringU(statAddress))));
 
             return stats;
         }
 
-        [Obsolete("Use IsFractured", false)]
-        public bool HaveFractured => IsFractured;
+        private string GetUniqueName(NativePtrArray source)
+        {
+            var words = new List<string>();
+            if (Address == 0)
+            {
+                return string.Empty;
+            }
 
-        [Obsolete("Use FracturedCount", false)]
-        public int CountFractured => FracturedCount;
-        [Obsolete("Use IsSynthesized", false)]
-        public bool Synthesised => IsSynthesized;
+            for (var first = source.First; first < source.Last; first += GameOffsets.Components.Mods.NameRecordSize)
+            {
+                words.Add(M.ReadStringU(M.Read<long>(first, GameOffsets.Components.Mods.NameOffset)).Trim());
+            }
+
+            return Cache.StringCache.Read($"{nameof(Mods)}{source.First}", () => string.Join(" ", words.ToArray()));
+        }
     }
 }

--- a/GameOffsets/ModsComponentOffsets.cs
+++ b/GameOffsets/ModsComponentOffsets.cs
@@ -4,33 +4,90 @@ using GameOffsets.Native;
 namespace GameOffsets
 {
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public readonly struct ModsComponentDetailsOffsets
+    {
+        [FieldOffset(0x008)] public readonly NativePtrArray ImplicitStatsArray;
+        [FieldOffset(0x048)] public readonly NativePtrArray EnchantedStatsArray;
+        [FieldOffset(0x088)] public readonly NativePtrArray ScourgeStatsArray;
+        [FieldOffset(0x0C8)] public readonly NativePtrArray ExplicitStatsArray;
+        [FieldOffset(0x108)] public readonly NativePtrArray CraftedStatsArray;
+        [FieldOffset(0x148)] public readonly NativePtrArray FracturedStatsArray;
+
+        // 3.16 Offsets
+        //[FieldOffset(0x008)] public readonly NativePtrArray ImplicitStatsArray;
+        //[FieldOffset(0x048)] public readonly NativePtrArray EnchantedStatsArray;
+        //[FieldOffset(0x088)] public readonly NativePtrArray ScourgeStatsArray;
+        //[FieldOffset(0x0C8)] public readonly NativePtrArray ExplicitStatsArray;
+        //[FieldOffset(0x108)] public readonly NativePtrArray CraftedStatsArray;
+        //[FieldOffset(0x148)] public readonly NativePtrArray FracturedStatsArray;
+        //[FieldOffset(0x190)] public readonly NativePtrArray ImplicitStatsArray2;
+        //[FieldOffset(0x1D0)] public readonly NativePtrArray EnchantedStatsArray2;
+        //[FieldOffset(0x210)] public readonly NativePtrArray ScourgeStatsArray2;
+        //[FieldOffset(0x250)] public readonly NativePtrArray ExplicitStatsArray2;
+        //[FieldOffset(0x290)] public readonly NativePtrArray CraftedStatsArray2;
+        //[FieldOffset(0x2D0)] public readonly NativePtrArray FracturedStatsArray2;
+        //[FieldOffset(0x318)] public readonly NativePtrArray Unknown0;
+        //[FieldOffset(0x358)] public readonly NativePtrArray Unknown1;
+        //[FieldOffset(0x430)] public readonly NativePtrArray Unknown2;
+        //[FieldOffset(0x478)] public readonly NativePtrArray ImplicitDescriptions;
+        //[FieldOffset(0x4B8)] public readonly NativePtrArray EnchantDescriptions;
+        //[FieldOffset(0x500)] public readonly NativePtrArray BasicPrefixDescriptions;
+        //[FieldOffset(0x518)] public readonly NativePtrArray CraftedPrefixDescriptions;
+        //[FieldOffset(0x530)] public readonly NativePtrArray FracturedPrefixDescriptions;
+        //[FieldOffset(0x548)] public readonly NativePtrArray BasicSuffixDescriptions;
+        //[FieldOffset(0x560)] public readonly NativePtrArray CraftedSuffixDescriptions;
+        //[FieldOffset(0x578)] public readonly NativePtrArray FracturedSuffixDescriptions;
+        //[FieldOffset(0x590)] public readonly NativePtrArray ScourgeDescriptions;
+    }
+    
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct ModsComponentOffsets
     {
-        public static readonly int ItemModRecordSize = 0x38;
-        public static readonly int NameRecordSize = 0x10;
-        public static readonly int NameOffset = 0x04;
-        public static readonly int StatRecordSize = 0x20;
+        [FieldOffset(0x030)] public readonly NativePtrArray UniqueName;
+        [FieldOffset(0x0A8)] public readonly bool Identified;
+        [FieldOffset(0x0AC)] public readonly int ItemRarity;
+        [FieldOffset(0x0B8)] public readonly NativePtrArray ImplicitModsArray;
+        [FieldOffset(0x0D0)] public readonly NativePtrArray ExplicitModsArray;
+        [FieldOffset(0x0E8)] public readonly NativePtrArray EnchantedModsArray;
+        [FieldOffset(0x100)] public readonly NativePtrArray ScourgeModsArray;
+        [FieldOffset(0x1D8)] public readonly long ModsComponentDetailsKey;
+        [FieldOffset(0x208)] public readonly int ItemLevel;
+        [FieldOffset(0x20C)] public readonly int RequiredLevel;
+        [FieldOffset(0x210)] public readonly long IncubatorKey;
+        [FieldOffset(0x220)] public readonly short IncubatorKillCount;
+        [FieldOffset(0x225)] public readonly byte IsMirrored;
+        [FieldOffset(0x226)] public readonly byte IsSplit;
+        [FieldOffset(0x227)] public readonly byte IsUsable;
 
-        [FieldOffset(0x30)] public NativePtrArray UniqueName;
-        [FieldOffset(0xA8)] public bool Identified;
-        [FieldOffset(0xAC)] public int ItemRarity;
-        [FieldOffset(0xB8)] public NativePtrArray ImplicitModsArray;
-        [FieldOffset(0xD0)] public NativePtrArray ExplicitModsArray;
-        [FieldOffset(0xE8)] public NativePtrArray EnchantedModsArray;
-        [FieldOffset(0x100)] public NativePtrArray ScourgeModsArray;
-        [FieldOffset(0x1D8)] public NativePtrArray ImplicitStatsArray;
-        [FieldOffset(0x218)] public NativePtrArray EnchantedStatsArray;
-        [FieldOffset(0x258)] public NativePtrArray ScourgeStatsArray;
-        [FieldOffset(0x298)] public NativePtrArray ExplicitStatsArray;
-        [FieldOffset(0x2D8)] public NativePtrArray CraftedStatsArray;
-        [FieldOffset(0x318)] public NativePtrArray FracturedStatsArray;
-        [FieldOffset(0x7C8)] public int ItemLevel;
-        [FieldOffset(0x7CC)] public int RequiredLevel;
-        [FieldOffset(0x7D0)] public long IncubatorKey;
-        [FieldOffset(0x7D8)] public short IncubatorKillCount;
-        
-        [FieldOffset(0x489)] public byte IsMirrored;
-        [FieldOffset(0x48A)] public byte IsSplit;
-        [FieldOffset(0x4AC)] public byte IsUsable;
+        public const int ItemModRecordSize = 0x38;
+        public const int NameOffset = 0x04;
+        public const int NameRecordSize = 0x10;
+        public const int StatRecordSize = 0x20;
+
+        // 3.16 Layout
+        //[FieldOffset(0x030)] public readonly NativePtrArray UniqueName;
+        //[FieldOffset(0x0A8)] public readonly bool Identified;
+        //[FieldOffset(0x0AC)] public readonly int ItemRarity;
+        //[FieldOffset(0x0B8)] public readonly NativePtrArray ImplicitModsArray;
+        //[FieldOffset(0x0D0)] public readonly NativePtrArray ExplicitModsArray;
+        //[FieldOffset(0x0E8)] public readonly NativePtrArray EnchantedModsArray;
+        //[FieldOffset(0x100)] public readonly NativePtrArray ScourgeModsArray;
+        //[FieldOffset(0x160)] public readonly NativePtrArray StatValuesArray;
+        //[FieldOffset(0x1C0)] public readonly long AlternateQualityTypeKey;
+        //[FieldOffset(0x1C8)] public readonly long AlternateQualityTypeFileKey;
+        //[FieldOffset(0x1D0)] public readonly int AlternateQualityAmount;
+        //[FieldOffset(0x1D8)] public readonly long ModsDetailsKey;
+        //[FieldOffset(0x1E0)] public readonly long StatDescriptionsFile1;
+        //[FieldOffset(0x1E8)] public readonly long StatDescriptionsFile2;
+        //[FieldOffset(0x1F0)] public readonly NativePtrArray Tags;
+        //[FieldOffset(0x208)] public readonly int ItemLevel;
+        //[FieldOffset(0x20C)] public readonly int RequiredLevel;
+        //[FieldOffset(0x210)] public readonly long IncubatorKey;
+        //[FieldOffset(0x218)] public readonly long IncubatorFile;
+        //[FieldOffset(0x220)] public readonly short IncubatorKillCount;
+        //[FieldOffset(ox222)] public readonly short IncubatorItemLevel;
+        //[FieldOffset(0x225)] public readonly byte IsMirrored;
+        //[FieldOffset(0x226)] public readonly byte IsSplit;
+        //[FieldOffset(0x227)] public readonly byte IsUsable;
     }
 }


### PR DESCRIPTION
All of the stat/descriptor information that used to be in mods was relocated to a different chunk of memory and a pointer to that chunk in the mods component now references it. The remaining non-stat/non-descriptor information shuffled forward.