### PR TITLE
Added modifier support for Keys

### DIFF
--- a/Core/MenuWindow.cs
+++ b/Core/MenuWindow.cs
@@ -210,7 +210,7 @@ namespace ExileCore
                 CoreSettings.MainMenuKeyToggle.Value = Keys.F12;
             }
 
-            if (CoreSettings.MainMenuKeyToggle.PressedOnce())
+            if (CoreSettings.MainMenuKeyToggle.PressedOnce() && !SettingsParser.ButtonPopupVisible)
             {
                 CoreSettings.Enable.Value = !CoreSettings.Enable;
 

--- a/Core/MenuWindow.cs
+++ b/Core/MenuWindow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using System.Windows.Forms;
 using ExileCore.RenderQ;
 using ExileCore.Shared;
 using ExileCore.Shared.Helpers;
@@ -201,6 +202,12 @@ namespace ExileCore
             if (CoreSettings.ShowDebugWindow)
             {
                 debugInformation.TickAction(DebugWindowRender);
+            }
+
+            // Prevent soft lock
+            if (CoreSettings.MainMenuKeyToggle.Value == Keys.LButton)
+            {
+                CoreSettings.MainMenuKeyToggle.Value = Keys.F12;
             }
 
             if (CoreSettings.MainMenuKeyToggle.PressedOnce())

--- a/Core/SettingsParser.cs
+++ b/Core/SettingsParser.cs
@@ -18,6 +18,8 @@ namespace ExileCore
 {
     public static class SettingsParser
     {
+        public static bool ButtonPopupVisible { get; private set; } = false;
+
         public static Type ListOfWhat(object list)
         {
             return !(list is IList) ? null : (Type) ListOfWhat2((dynamic) list);
@@ -196,7 +198,11 @@ namespace ExileCore
 
                         // Create modal
                         var popupOpened = true;
-                        if (!ImGui.BeginPopupModal(str, ref popupOpened, ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse))
+                        if (ImGui.BeginPopupModal(str, ref popupOpened, ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse))
+                        {
+                            ButtonPopupVisible = true;
+                        }
+                        else
                         {
                             return;
                         }
@@ -206,6 +212,7 @@ namespace ExileCore
                         {
                             ImGui.CloseCurrentPopup();
                             ImGui.EndPopup();
+                            ButtonPopupVisible = false;
                             return;
                         }
 
@@ -218,6 +225,7 @@ namespace ExileCore
                             // Set the node's value to the keys that were pressed and close the popup
                             hotkeyNode.Value = key;
                             ImGui.CloseCurrentPopup();
+                            ButtonPopupVisible = false;
                         }
 
                         // End popup

--- a/Core/SettingsParser.cs
+++ b/Core/SettingsParser.cs
@@ -184,18 +184,24 @@ namespace ExileCore
                     holder.DrawDelegate = () =>
                     {
                         var str = $"{holder.Name} {hotkeyNode.Value}##{hotkeyNode.Value}";
-                        var popupOpened = true;
 
                         if (ImGui.Button(str))
                         {
+                            // Clear async buffer state
+                            Input.ClearAsyncBuffer();
+
+                            // Begin pop up
                             ImGui.OpenPopup(str);
-                            popupOpened = true;
                         }
 
-                        if (!ImGui.BeginPopupModal(str, ref popupOpened,
-                            ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse))
+                        // Create modal
+                        var popupOpened = true;
+                        if (!ImGui.BeginPopupModal(str, ref popupOpened, ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse))
+                        {
                             return;
+                        }
 
+                        // Close popup if escape was pressed
                         if (Input.GetKeyState(Keys.Escape))
                         {
                             ImGui.CloseCurrentPopup();
@@ -203,14 +209,18 @@ namespace ExileCore
                             return;
                         }
 
-                        foreach (var key in Enum.GetValues(typeof(Keys)))
+                        // Get prssed keys
+                        Keys key = Input.GetPressedKeys(true);
+
+                        // If a key was pressed, set value and close popup
+                        if ((key & Keys.KeyCode) != Keys.None)
                         {
-                            if (!Input.GetKeyState((Keys) key)) continue;
-                            hotkeyNode.Value = (Keys) key;
+                            // Set the node's value to the keys that were pressed and close the popup
+                            hotkeyNode.Value = key;
                             ImGui.CloseCurrentPopup();
-                            break;
                         }
 
+                        // End popup
                         ImGui.Text($"Press new key to change '{hotkeyNode.Value}' or Esc for exit.");
                         ImGui.EndPopup();
                     };


### PR DESCRIPTION
I've updated the program to allow modifiers on key nodes and modifiers on key input actions. This should allow you to map skill hotkeys that require combinations like CTRL + Q and gives the user the option to show and hide the menus with combinations like Shift + K.