### PR TITLE
Added reference to StaticResources to Loader in order to prevent exception with missing icon.

### DIFF
--- a/Loader/Loader.csproj
+++ b/Loader/Loader.csproj
@@ -50,6 +50,9 @@
     <Content Include="poehud.ico" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\StaticResources\StaticResources.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="AppForm.resx">
       <DependentUpon>AppForm.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
StaticResourses has recourse required in Loader.exe, so it should be referenced in Loader.