### PR TITLE
Offsets and Inventory fixes

### DIFF
--- a/Core/PoEMemory/Components/HeistRewardDisplay.cs
+++ b/Core/PoEMemory/Components/HeistRewardDisplay.cs
@@ -1,13 +1,21 @@
-﻿using ExileCore.PoEMemory.MemoryObjects;
-using ExileCore.Shared.Enums;
-using ExileCore.Shared.Helpers;
-using GameOffsets.Native;
-using GameOffsets;
-using ExileCore.Shared.Cache;
-
 namespace ExileCore.PoEMemory.Components
 {
-    public class HeistRewardDisplay: Component
+    using ExileCore.PoEMemory.MemoryObjects;
+    using ExileCore.Shared.Cache;
+    using GameOffsets;
+
+    public class HeistRewardDisplay : Component
     {
+        private readonly CachedValue<HeistRewardDisplayComponentOffsets> CachedData;
+
+        public HeistRewardDisplay()
+        {
+            this.CachedData
+                = new FrameCache<HeistRewardDisplayComponentOffsets>(() => this.M.Read<HeistRewardDisplayComponentOffsets>(this.Address));
+        }
+
+        public Entity RewardItem => this.GetObject<Entity>(this._data.RewardItemKey);
+
+        private HeistRewardDisplayComponentOffsets _data => this.CachedData.Value;
     }
 }

--- a/Core/PoEMemory/Elements/InventoryElements/DivinationInventoryItem.cs
+++ b/Core/PoEMemory/Elements/InventoryElements/DivinationInventoryItem.cs
@@ -11,14 +11,15 @@ namespace ExileCore.PoEMemory.Elements.InventoryElements
 
         public override RectangleF GetClientRect()
         {
-            var tmp = Parent.GetClientRect();
+            var unshiftedPosition = this.Parent.Parent.GetClientRect();
 
-            // div stash tab scrollbar element scroll value calculator
-            var addr = Parent.Parent.Parent.Parent.Children[2].Address + 0xA64;
-            var sub = M.Read<int>(addr) * (float) 107.5;
-            tmp.Y -= sub;
+            var scrollBarPanel = this.Parent.Parent.Parent.Parent[2];
 
-            return tmp;
+            var currentTicksY = this.M.Read<int>(scrollBarPanel.Address + 0x29C);
+
+            unshiftedPosition.Y -= 72.56f * currentTicksY; // TODO: Check if needs to be scaled by resolution
+
+            return unshiftedPosition;
         }
     }
 }

--- a/Core/PoEMemory/Elements/InventoryElements/EldritchMavenFragmentInventoryItem.cs
+++ b/Core/PoEMemory/Elements/InventoryElements/EldritchMavenFragmentInventoryItem.cs
@@ -1,0 +1,21 @@
+﻿namespace ExileCore.PoEMemory.Elements.InventoryElements
+{
+    using SharpDX;
+
+    public class EldritchMavenFragmentInventoryItem : NormalInventoryItem
+    {
+        public override int InventPosX => base.InventPosX % 12;
+
+        public override RectangleF GetClientRect()
+        {
+            var baseDimensions = base.GetClientRect();
+            var parentDimensions = this.Parent.GetClientRectCache;
+
+            return new RectangleF(
+                parentDimensions.TopLeft.X + (this.InventPosX * baseDimensions.Width),
+                parentDimensions.TopLeft.Y,
+                baseDimensions.Width,
+                baseDimensions.Height);
+        }
+    }
+}

--- a/Core/PoEMemory/Elements/InventoryElements/FlaskInventoryItem.cs
+++ b/Core/PoEMemory/Elements/InventoryElements/FlaskInventoryItem.cs
@@ -1,0 +1,16 @@
+﻿namespace ExileCore.PoEMemory.Elements.InventoryElements
+{
+    using SharpDX;
+
+    public class FlaskInventoryItem : NormalInventoryItem
+    {
+        public override int InventPosX => 0;
+
+        public override int InventPosY => 0;
+
+        public override RectangleF GetClientRect()
+        {
+            return this.Parent.GetClientRect();
+        }
+    }
+}

--- a/Core/PoEMemory/Elements/InventoryElements/FragmentInventoryItem.cs
+++ b/Core/PoEMemory/Elements/InventoryElements/FragmentInventoryItem.cs
@@ -1,17 +1,18 @@
-﻿using SharpDX;
-
 namespace ExileCore.PoEMemory.Elements.InventoryElements
 {
+    using SharpDX;
+
     public class FragmentInventoryItem : NormalInventoryItem
     {
         // Inventory Position in Currency Stash is always invalid.
         // Also, as items are fixed, so Inventory Position doesn't matter.
         public override int InventPosX => 0;
+
         public override int InventPosY => 0;
 
         public override RectangleF GetClientRect()
         {
-            return Parent.GetClientRect();
+            return this.Parent.GetClientRect();
         }
     }
 }

--- a/Core/PoEMemory/Elements/InventoryElements/GemInventoryItem.cs
+++ b/Core/PoEMemory/Elements/InventoryElements/GemInventoryItem.cs
@@ -1,0 +1,16 @@
+﻿namespace ExileCore.PoEMemory.Elements.InventoryElements
+{
+    using SharpDX;
+
+    public class GemInventoryItem : NormalInventoryItem
+    {
+        public override int InventPosX => 0;
+
+        public override int InventPosY => 0;
+
+        public override RectangleF GetClientRect()
+        {
+            return this.Parent.GetClientRect();
+        }
+    }
+}

--- a/Core/PoEMemory/MemoryObjects/IngameUIElements.cs
+++ b/Core/PoEMemory/MemoryObjects/IngameUIElements.cs
@@ -86,7 +86,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public Cursor Cursor => _cursor ??= GetObject<Cursor>(IngameUIElementsStruct.Mouse);
         public Element BetrayalWindow => _BetrayalWindow ??= GetObject<Element>(IngameUIElementsStruct.BetrayalWindow);
         public Element SyndicatePanel => BetrayalWindow; // Required for TehCheats Api, BroodyHen uses this.
-        public Element SyndicateTree => GetObject<Element>(M.Read<long>(BetrayalWindow.Address + 0xA50));
+        public Element SyndicateTree => BetrayalWindow[0];
         public Element UnveilWindow => _UnveilWindow ??= GetObject<Element>(IngameUIElementsStruct.UnveilWindow);
         public Element ZanaMissionChoice => _ZanaMissionChoice ??= GetObject<Element>(IngameUIElementsStruct.ZanaMissionChoice);
         public IncursionWindow IncursionWindow => _IncursionWindow ??= GetObject<IncursionWindow>(IngameUIElementsStruct.IncursionWindow);

--- a/Core/Shared/Enums/InventoryType.cs
+++ b/Core/Shared/Enums/InventoryType.cs
@@ -2,7 +2,7 @@ namespace ExileCore.Shared.Enums
 {
     public enum InventoryType
     {
-        InvalidInventory, //Incase inventory isn't opened.
+        InvalidInventory,
         PlayerInventory,
         NormalStash,
         QuadStash,
@@ -15,6 +15,8 @@ namespace ExileCore.Shared.Enums
         UniqueStash,
         BlightStash,
         DeliriumStash,
-        MetamorphStash
+        MetamorphStash,
+        FlaskStash,
+        GemStash
     }
 }

--- a/GameOffsets/HeistRewardDisplayComponentOffsets.cs
+++ b/GameOffsets/HeistRewardDisplayComponentOffsets.cs
@@ -1,0 +1,11 @@
+﻿namespace GameOffsets
+{
+    using System.Runtime.InteropServices;
+
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public struct HeistRewardDisplayComponentOffsets
+    {
+        [FieldOffset(0x48)] public long RewardItemKey;
+    }
+}
+

--- a/GameOffsets/InventoryOffsets.cs
+++ b/GameOffsets/InventoryOffsets.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using GameOffsets.Native;
 
 namespace GameOffsets
@@ -8,13 +8,15 @@ namespace GameOffsets
     {
         [FieldOffset(0x260)] public int MoveItemHoverState;
         [FieldOffset(0x268)] public long HoverItem;
+        // [FieldOffset(0x270)] public Vector2i HoveredGridPosition;
         [FieldOffset(0x270)] public int XFake;
         [FieldOffset(0x274)] public int YFake;
+        // [FieldOffset(0x278)] public Vector2i HoveredSlotPosition;
         [FieldOffset(0x278)] public int XReal;
         [FieldOffset(0x27C)] public int YReal;
         [FieldOffset(0x288)] public short CursorInInventory;
-        [FieldOffset(0x410)] public long ItemCount;
-        [FieldOffset(0x494)] public Vector2i InventorySize;
-        [FieldOffset(0x494)] public int TotalBoxesInInventoryRow;
+        [FieldOffset(0x3E8)] public long ItemCount;
+        [FieldOffset(0x46C)] public Vector2i InventorySize;
+        [FieldOffset(0x46C)] public int TotalBoxesInInventoryRow;
     }
 }

--- a/GameOffsets/ServerDataOffsets.cs
+++ b/GameOffsets/ServerDataOffsets.cs
@@ -1,9 +1,8 @@
-using System.Runtime.InteropServices;
-using System.Security.Policy;
-using GameOffsets.Native;
-
 namespace GameOffsets
 {
+    using System.Runtime.InteropServices;
+    using GameOffsets.Native;
+
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct SkillBarIdsStruct
     {
@@ -58,7 +57,7 @@ namespace GameOffsets
         // [FieldOffset(0x24C)] public readonly int TotalAscendencyPoints;
         // [FieldOffset(0x250)] public readonly int SpentAscendencyPoints;
     }
-    
+
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct ServerDataOffsets
     {
@@ -82,92 +81,100 @@ namespace GameOffsets
         [FieldOffset(0x9A08 - Skip)] public readonly ushort TradeChatChannel;
         [FieldOffset(0x9A10 - Skip)] public readonly ushort GlobalChatChannel;
         [FieldOffset(0x9AB0 - Skip)] public readonly ushort LastActionId;
-        [FieldOffset(0x93C8 - Skip)] public readonly long MavenMapsList;
-        [FieldOffset(0x93D0 - Skip)] public readonly long MavenMapsCount;
-        [FieldOffset(0x93D8 - Skip)] public readonly long MavenMapsArray;
-        [FieldOffset(0x9408 - Skip)] public readonly long CompletedMapsList;
-        [FieldOffset(0x9410 - Skip)] public readonly long CompletedMapsCount;
-        [FieldOffset(0x9418 - Skip)] public readonly long CompletedMapsArray;
-        [FieldOffset(0x9448 - Skip)] public readonly long BonusCompletedAreasList;
-        [FieldOffset(0x9450 - Skip)] public readonly long BonusCompletedAreasCount;
-        [FieldOffset(0x9458 - Skip)] public readonly long BonusCompletedAreasArray;
-        [FieldOffset(0x9488 - Skip)] public readonly long FavouredMapsArray;
-        [FieldOffset(0x94A2 - Skip)] public readonly AtlasMissionAmounts LowTierAtlasMissionAmounts;
-        [FieldOffset(0x94B0 - Skip)] public readonly AtlasMissionAmounts MidTierAtlasMissionAmounts;
-        [FieldOffset(0x94BE - Skip)] public readonly AtlasMissionAmounts HighTierAtlasMissionAmounts;
-        [FieldOffset(0x94CC - Skip)] public readonly byte SocketedWatchstones;
-        [FieldOffset(0x9588 - Skip)] public readonly long BestiaryCapturedMonsterList;
-        [FieldOffset(0x95A0 - Skip)] public readonly int DialogDepth;
-        [FieldOffset(0x95A4 - Skip)] public readonly byte MonsterLevel;
-        [FieldOffset(0x95A5 - Skip)] public readonly byte MonstersRemaining;
-        [FieldOffset(0x9652 - Skip)] public readonly int CurrentAzuriteAmount;
-        [FieldOffset(0x9662 - Skip)] public readonly ushort CurrentSulphiteAmount;
-        
-        public const int BestiaryBeastsCapturedCounts = 0x9610;
-        
+        [FieldOffset(0x9B08 - Skip)] public readonly long MavenMapsList;
+        [FieldOffset(0x9B10 - Skip)] public readonly long MavenMapsCount;
+        [FieldOffset(0x9B18 - Skip)] public readonly long MavenMapsArray;
+        [FieldOffset(0x9B48 - Skip)] public readonly long CompletedMapsList;
+        [FieldOffset(0x9B50 - Skip)] public readonly long CompletedMapsCount;
+        [FieldOffset(0x9B58 - Skip)] public readonly long CompletedMapsArray;
+        [FieldOffset(0x9B88 - Skip)] public readonly long BonusCompletedAreasList;
+        [FieldOffset(0x9B90 - Skip)] public readonly long BonusCompletedAreasCount;
+        [FieldOffset(0x9B98 - Skip)] public readonly long BonusCompletedAreasArray;
+        [FieldOffset(0x9C00 - Skip)] public readonly long FavouredMapsArray;
+        [FieldOffset(0x9C1A - Skip)] public readonly AtlasMissionAmounts LowTierAtlasMissionAmounts;
+        [FieldOffset(0x9C28 - Skip)] public readonly AtlasMissionAmounts MidTierAtlasMissionAmounts;
+        [FieldOffset(0x9C36 - Skip)] public readonly AtlasMissionAmounts HighTierAtlasMissionAmounts;
+        [FieldOffset(0x9C44 - Skip)] public readonly byte SocketedWatchstones;
+        [FieldOffset(0x9D00 - Skip)] public readonly long BestiaryCapturedMonsterList;
+        [FieldOffset(0xA5A0 - Skip)] public readonly int DialogDepth;
+        [FieldOffset(0xA5A4 - Skip)] public readonly byte MonsterLevel;
+        [FieldOffset(0xA5A5 - Skip)] public readonly byte MonstersRemaining;
+        [FieldOffset(0xA652 - Skip)] public readonly int CurrentAzuriteAmount;
+        [FieldOffset(0xA662 - Skip)] public readonly ushort CurrentSulphiteAmount;
+
+        public const int BestiaryBeastsCapturedCounts = 0x9D88;
+
         // 3.17 Layout
-        // [FieldOffset(0x89A0 - Skip)] public readonly long PlayerRelatedData;
-        // [FieldOffset(0x89B8 - Skip)] public readonly byte NetworkState;
-        // [FieldOffset(0x89D0 - Skip)] public readonly NativeStringU League;
-        // [FieldOffset(0x8A50 - Skip)] public readonly int TimeInGame;
-        // [FieldOffset(0x8A70 - Skip)] public readonly int Latency;
-        // [FieldOffset(0x8A78 - Skip)] public readonly NativePtrArray PlayerStashTabs;
-        // [FieldOffset(0x8A90 - Skip)] public readonly NativePtrArray GuildStashTabs;
-        // [FieldOffset(0x8B60 - Skip)] public readonly long FriendsListMap;
-        // [FieldOffset(0x8B78 - Skip)] public readonly long FriendList;
-        // [FieldOffset(0x8B88 - Skip)] public readonly NativePtrArray FriendListArray;
-        // [FieldOffset(0x8BC8 - Skip)] public readonly NativePtrArray PendingInvites;
-        // [FieldOffset(0x8C08 - Skip)] public readonly long PartyPublicDescription;
-        // [FieldOffset(0x8C28 - Skip)] public readonly long PartyLeaderKey;
-        // [FieldOffset(0x8C48 - Skip)] public readonly byte PartyStatusType;
-        // [FieldOffset(0x8C50 - Skip)] public readonly NativePtrArray CurrentParty;
-        // [FieldOffset(0x8C68 - Skip)] public readonly byte PartyAllocationType;
-        // [FieldOffset(0x8C69 - Skip)] public readonly bool PartyDownscaleDisabled;
-        // [FieldOffset(0x8C80 - Skip)] public readonly long GuildList;
-        // [FieldOffset(0x8C90 - Skip)] public readonly NativePtrArray GuildArray;
-        // [FieldOffset(0x8CD0 - Skip)] public readonly long GuildNameAddress;
-        // [FieldOffset(0x8CE0 - Skip)] public readonly SkillBarIdsStruct SkillBarIds;
-        // [FieldOffset(0x8CFC - Skip)] public readonly float MouseWorldPosX;
-        // [FieldOffset(0x8D00 - Skip)] public readonly float MouseWorldPosY;
-        // [FieldOffset(0x8D10 - Skip)] public readonly long SkillBarUiRootKey;
-        // [FieldOffset(0x8D40 - Skip)] public readonly NativePtrArray NearestPlayers;
-        // [FieldOffset(0x8D70 - Skip)] public readonly NativePtrArray MinimapIcons;
-        // [FieldOffset(0x8D90 - Skip)] public readonly NativePtrArray LocalPlayer;
-        // [FieldOffset(0x8EB8 - Skip)] public readonly NativePtrArray PlayerInventories;
-        // [FieldOffset(0x9008 - Skip)] public readonly NativePtrArray NPCInventories;
-        // [FieldOffset(0x9158 - Skip)] public readonly NativePtrArray GuildInventories;
-        // [FieldOffset(0x9178 - Skip)] public readonly NativeStringU SocialMessage;
-        // [FieldOffset(0x92C8 - Skip)] public readonly ushort TradeChatChannel;
-        // [FieldOffset(0x9CD0 - Skip)] public readonly ushort GlobalChatChannel;
-        // [FieldOffset(0x9370 - Skip)] public readonly ushort LastActionId;
-        // [FieldOffset(0x93A8 - Skip)] public readonly long InstanceLeagueInfo;
-        // [FieldOffset(0x93C8 - Skip)] public readonly long MavenMapsList;
-        // [FieldOffset(0x93D0 - Skip)] public readonly long MavenMapsCount;
-        // [FieldOffset(0x93D8 - Skip)] public readonly long MavenMapsArray;
-        // [FieldOffset(0x9408 - Skip)] public readonly long CompletedMapsList;
-        // [FieldOffset(0x9410 - Skip)] public readonly long CompletedMapsCount;
-        // [FieldOffset(0x9418 - Skip)] public readonly long CompletedMapsArray;
-        // [FieldOffset(0x9448 - Skip)] public readonly long BonusCompletedAreasList;
-        // [FieldOffset(0x9450 - Skip)] public readonly long BonusCompletedAreasCount;
-        // [FieldOffset(0x9458 - Skip)] public readonly long BonusCompletedAreasArray;
-        // [FieldOffset(0x9488 - Skip)] public readonly long FavouredMapsArray;
-        // [FieldOffset(0x94A2 - Skip)] public readonly AtlasMissionAmounts LowTierAtlasMissionAmounts;
-        // [FieldOffset(0x94B0 - Skip)] public readonly AtlasMissionAmounts MidTierAtlasMissionAmounts;
-        // [FieldOffset(0x94BE - Skip)] public readonly AtlasMissionAmounts HighTierAtlasMissionAmounts;
-        // [FieldOffset(0x94CC - Skip)] public readonly byte SocketedWatchstones;
-        // [FieldOffset(0x9588 - Skip)] public readonly long BestiaryCapturedMonsterList;
+        // [FieldOffset(0x8D20 - Skip)] public readonly long PlayerRelatedData;
+        // [FieldOffset(0x8D38 - Skip)] public readonly byte NetworkState;
+        // [FieldOffset(0x8D50 - Skip)] public readonly NativeStringU League;
+        // [FieldOffset(0x8DD0 - Skip)] public readonly int TimeInGame;
+        // [FieldOffset(0x8DF0 - Skip)] public readonly int Latency;
+        // [FieldOffset(0x8DF8 - Skip)] public readonly NativePtrArray PlayerStashTabs;
+        // [FieldOffset(0x8E10 - Skip)] public readonly NativePtrArray GuildStashTabs;
+        // [FieldOffset(0x8EE0 - Skip)] public readonly long FriendsListMap;
+        // [FieldOffset(0x8EF8 - Skip)] public readonly long FriendList;
+        // [FieldOffset(0x8F08 - Skip)] public readonly NativePtrArray FriendListArray;
+        // [FieldOffset(0x8F48 - Skip)] public readonly NativePtrArray PendingInvites;
+        // [FieldOffset(0x8F88 - Skip)] public readonly long PartyPublicDescription;
+        // [FieldOffset(0x8FA8 - Skip)] public readonly long PartyLeaderKey;
+        // [FieldOffset(0x8FC8 - Skip)] public readonly byte PartyStatusType;
+        // [FieldOffset(0x8FD0 - Skip)] public readonly NativePtrArray CurrentParty;
+        // [FieldOffset(0x8FE8 - Skip)] public readonly byte PartyAllocationType;
+        // [FieldOffset(0x8FE9 - Skip)] public readonly bool PartyDownscaleDisabled;
+        // [FieldOffset(0x9000 - Skip)] public readonly long GuildList;
+        // [FieldOffset(0x9010 - Skip)] public readonly NativePtrArray GuildArray;
+        // [FieldOffset(0x9050 - Skip)] public readonly long GuildNameAddress;
+        // [FieldOffset(0x9060 - Skip)] public readonly SkillBarIdsStruct SkillBarIds;
+        // [FieldOffset(0x907C - Skip)] public readonly float MouseWorldPosX;
+        // [FieldOffset(0x9080 - Skip)] public readonly float MouseWorldPosY;
+        // [FieldOffset(0x9088 - Skip)] public readonly long SkillBarUiRootKey;
+        // [FieldOffset(0x90C0 - Skip)] public readonly NativePtrArray NearestPlayers;
+        // [FieldOffset(0x90F0 - Skip)] public readonly NativePtrArray MinimapIcons;
+        // [FieldOffset(0x9110 - Skip)] public readonly NativePtrArray LocalPlayer;
+        // [FieldOffset(0x9378 - Skip)] public readonly NativePtrArray PlayerInventories;
+        // [FieldOffset(0x9608 - Skip)] public readonly NativePtrArray NPCInventories;
+        // [FieldOffset(0x9898 - Skip)] public readonly NativePtrArray GuildInventories;
+        // [FieldOffset(0x98B8 - Skip)] public readonly NativeStringU SocialMessage;
+        // [FieldOffset(0x9A08 - Skip)] public readonly ushort TradeChatChannel;
+        // [FieldOffset(0x9A10 - Skip)] public readonly ushort GlobalChatChannel;
+        // [FieldOffset(0x9AB0 - Skip)] public readonly ushort LastActionId;
+        // [FieldOffset(0x9AE8 - Skip)] public readonly long InstanceLeagueInfo;
+        // [FieldOffset(0x9B08 - Skip)] public readonly long MavenMapsList;
+        // [FieldOffset(0x9B10 - Skip)] public readonly long MavenMapsCount;
+        // [FieldOffset(0x9B18 - Skip)] public readonly long MavenMapsArray;
+        // [FieldOffset(0x9B48 - Skip)] public readonly long CompletedMapsList;
+        // [FieldOffset(0x9B50 - Skip)] public readonly long CompletedMapsCount;
+        // [FieldOffset(0x9B58 - Skip)] public readonly long CompletedMapsArray;
+        // [FieldOffset(0x9B88 - Skip)] public readonly long BonusCompletedAreasList;
+        // [FieldOffset(0x9B90 - Skip)] public readonly long BonusCompletedAreasCount;
+        // [FieldOffset(0x9B98 - Skip)] public readonly long BonusCompletedAreasArray;
+        // [FieldOffset(0x9C00 - Skip)] public readonly long FavouredMapsArray;
+        // [FieldOffset(0x9C1A - Skip)] public readonly AtlasMissionAmounts LowTierAtlasMissionAmounts;
+        // [FieldOffset(0x9C28 - Skip)] public readonly AtlasMissionAmounts MidTierAtlasMissionAmounts;
+        // [FieldOffset(0x9C36 - Skip)] public readonly AtlasMissionAmounts HighTierAtlasMissionAmounts;
+        // [FieldOffset(0x9C44 - Skip)] public readonly byte SocketedWatchstones;
+        // [FieldOffset(0x9D00 - Skip)] public readonly long BestiaryCapturedMonsterList;
+        // [FieldOffset(0x9D88 - Skip)] public fixed int BestiaryBeastCaptureCounts[470];
         // [FieldOffset(0x9DF8 - Skip)] public readonly long LeftIncursionArchitectKey;
         // [FieldOffset(0x9E08 - Skip)] public readonly long RightIncursionArchitectKey;
-        // [FieldOffset(0x9E28 - Skip)] public readonly int DialogDepth;
-        // [FieldOffset(0x9E2C - Skip)] public readonly byte MonsterLevel;
-        // [FieldOffset(0x9E2D - Skip)] public readonly byte MonstersRemaining;
-        // [FieldOffset(0x9EDA - Skip)] public readonly int CurrentAzuriteAmount;
-        // [FieldOffset(0x9EEA - Skip)] public readonly ushort CurrentSulphiteAmount;
-        // [FieldOffset(0x9F38 - Skip)] public readonly long DeliriumRewardInfo;
-        // [FieldOffset(0x9F50 - Skip)] public readonly long HeistBlueprintInfo;
-        // [FieldOffset(0x9F68 - Skip)] public readonly long HeistContractInfo;
-        // [FieldOffset(0x9FB8 - Skip)] public readonly int CrucibleExperience;
-        
-        // public const int BestiaryBeastsCapturedCounts = 0x9610;
+        // [FieldOffset(0xA5A0 - Skip)] public readonly int DialogDepth;
+        // [FieldOffset(0xA5A4 - Skip)] public readonly byte MonsterLevel;
+        // [FieldOffset(0xA5A5 - Skip)] public readonly byte MonstersRemaining;
+        // [FieldOffset(0xA64C - Skip)] public readonly byte DelveFlareCount;
+        // [FieldOffset(0xA64D - Skip)] public readonly byte DelveDynamiteCount;
+        // [FieldOffset(0xA652 - Skip)] public readonly int CurrentAzuriteAmount;
+        // [FieldOffset(0xA659 - Skip)] public readonly byte DelveMaximumFlareTier;
+        // [FieldOffset(0xA65A - Skip)] public readonly byte DelveMaximumDynamiteTier;
+        // [FieldOffset(0xA65C - Skip)] public readonly byte DelveFlareRadiusTier;
+        // [FieldOffset(0xA65D - Skip)] public readonly byte DelveDynamiteRadiusTier;
+        // [FieldOffset(0xA65F - Skip)] public readonly byte DelveDynamiteDamageTier;
+        // [FieldOffset(0xA661 - Skip)] public readonly byte DelveFlareDurationTier;
+        // [FieldOffset(0xA662 - Skip)] public readonly ushort CurrentSulphiteAmount;
+        // [FieldOffset(0xA7A8 - Skip)] public readonly NativePtrArray HorticraftingRecipes;
+        // [FieldOffset(0xAF38 - Skip)] public readonly long DeliriumRewardInfo;
+        // [FieldOffset(0xAF50 - Skip)] public readonly long HeistBlueprintInfo;
+        // [FieldOffset(0xAF68 - Skip)] public readonly long HeistContractInfo;
+        // [FieldOffset(0xAFB8 - Skip)] public readonly int CrucibleExperience;
     }
 }


### PR DESCRIPTION
Each stash tab now correctly generates the list of locally visible items (not actually visible items). This includes adding the recent flask and gem tabs. Only tab I don't have is a quad tab, so someone else can make sure it still reports 24 boxes correctly.