### PR TITLE
Adds new UI element: ToggleHotkeyNode

### DIFF
--- a/Core/SettingsParser.cs
+++ b/Core/SettingsParser.cs
@@ -182,6 +182,50 @@ namespace ExileCore
                 case EmptyNode _:
                     holder.DrawDelegate = () => { };
                     return;
+                case ToggleHotkeyNode toggleHotkeyNode:
+                    holder.DrawDelegate = () =>
+                    {
+
+                        ImGui.Columns(2);
+                        ImGui.SetColumnWidth(0, 35);
+                        var isChecked = toggleHotkeyNode.Enabled;
+                        ImGui.Checkbox("  " + holder.Unique, ref isChecked);
+                        toggleHotkeyNode.Enabled = isChecked;
+                        ImGui.NextColumn();
+
+                        var str = $"{holder.Name} {toggleHotkeyNode.Value}##{toggleHotkeyNode.Value}";
+                        var popupOpened = true;
+
+                        if (ImGui.Button(str))
+                        {
+                            ImGui.OpenPopup(str);
+                            popupOpened = true;
+                        }
+                        ImGui.NextColumn();
+
+                        if (!ImGui.BeginPopupModal(str, ref popupOpened,
+                            ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse))
+                            return;
+
+                        if (Input.GetKeyState(Keys.Escape))
+                        {
+                            ImGui.CloseCurrentPopup();
+                            ImGui.EndPopup();
+                            return;
+                        }
+
+                        foreach (var key in Enum.GetValues(typeof(Keys)))
+                        {
+                            if (!Input.GetKeyState((Keys)key)) continue;
+                            toggleHotkeyNode.Value = (Keys)key;
+                            ImGui.CloseCurrentPopup();
+                            break;
+                        }
+
+                        ImGui.Text($"Press new key to change '{toggleHotkeyNode.Value}' or Esc for exit.");
+                        ImGui.EndPopup();
+                    };
+                    return;
                 case HotkeyNode hotkeyNode:
                     holder.DrawDelegate = () =>
                     {

--- a/Core/Shared/Nodes/HotkeyNode.cs
+++ b/Core/Shared/Nodes/HotkeyNode.cs
@@ -5,6 +5,14 @@ using SharpDX;
 
 namespace ExileCore.Shared.Nodes
 {
+    public class ToggleHotkeyNode : HotkeyNode
+    {
+        public bool Enabled { get; set; } = false;
+        public ToggleHotkeyNode(Keys key) : base(key) { }
+        public static implicit operator Keys(ToggleHotkeyNode node) => node.Value;
+        public static implicit operator ToggleHotkeyNode(Keys value) => new ToggleHotkeyNode(value);
+        public static implicit operator bool(ToggleHotkeyNode node) => node.Enabled;
+    }
     public class HotkeyNode
     {
         private bool _pressed;

--- a/Core/Shared/Nodes/HotkeyNode.cs
+++ b/Core/Shared/Nodes/HotkeyNode.cs
@@ -7,7 +7,11 @@ namespace ExileCore.Shared.Nodes
 {
     public class ToggleHotkeyNode : HotkeyNode
     {
-        public bool Enabled { get; set; } = false;
+        public bool Enabled {
+            get { return enabled; }
+            set { if ( value != enabled ) { enabled = value; OnValueChanged(); } }
+        }
+        private bool enabled = false;
         public ToggleHotkeyNode(Keys key) : base(key) { }
         public static implicit operator Keys(ToggleHotkeyNode node) => node.Value;
         public static implicit operator ToggleHotkeyNode(Keys value) => new ToggleHotkeyNode(value);


### PR DESCRIPTION
This new element combines a checkbox (and .Enabled flag) like ToggleNode, but also integrates the key binding popup from HotkeyNode.

This way you end up with a toggle-able HotKey with an interface that fits nicely in one element (on one line of the interface).

In lieu of screenshots (cant launch to get one until new offsets are posted), the UI looks like this:

[ x ] | [ Cast Molten Shell R ]

Using the previously available elements you could only make a UI like this:
[ x ] Enable Molten Shell
[ Molten Shell Key R ]

This gets really clunky once you want to list out even a few items.

The resulting object is just like both existing ToggleNode (which has a bool .Enabled) and HotKeyNode (which has a Keys .Value).

